### PR TITLE
[feat]#18 분석 리포트 RAG + LLM 문구 생성

### DIFF
--- a/app/domain/report/report_llm_service.py
+++ b/app/domain/report/report_llm_service.py
@@ -1,0 +1,171 @@
+import json
+import os
+import re
+from typing import Any
+
+from openai import AsyncOpenAI
+from app.core.config import settings
+
+class ReportLlmService:
+    def __init__(self):
+        self.base_url = settings.REPORT_LLM_BASE_URL
+        self.api_key = settings.REPORT_LLM_API_KEY
+        self.model = settings.REPORT_LLM_MODEL
+
+        self.client = AsyncOpenAI(base_url=self.base_url, api_key=self.api_key)
+
+    async def generate_sections(self, *, user_level:str, report_mode:str, growth_index:float, weak_section:str, weak_quiz:str, weakest_metric:str, present_growth: dict[str,float], evidence_docs: list[dict[str,Any]]) -> dict[str,str]:
+        fallback = self._fallback_texts(
+            report_mode=report_mode,
+            weakest_metric=weakest_metric,
+            weak_section=weak_section,
+            weak_quiz=weak_quiz,
+        )
+
+
+        if report_mode == "WARM_UP":
+            return fallback
+
+        system_prompt = (
+            "너는 코딩 학습 분석 리포트를 작성하는 코치다. "
+            "반드시 JSON 객체만 출력해야 한다. "
+            "마크다운, 코드블록, 설명 문장 없이 JSON만 반환한다. "
+            "필수 키는 summary_comment, analysis_text, strategy_tip, recommended_action 이다. "
+            "전체 톤은 밝고 따뜻하되, 지나치게 감성적이지 않고 전문적인 서비스 문구처럼 작성한다. "
+            "사용자의 부족함을 단정적으로 표현하지 않는다. "
+            "특히 summary_comment는 사용자의 성장 흐름을 긍정적으로 짚어주면서도 과장되지 않게 작성한다."
+        )
+
+        evidence_text = "\n".join(
+            [
+                f"- concept={d.get('concept','UNKNOWN')}"
+                f"definition={d.get('definition','')},"
+                f"core_logic={d.get('core_logic','')}"
+                f"check_points={d.get('check_points',[])}"
+                for d in evidence_docs[:3]
+            ]
+        ) or "-없음"
+
+        user_prompt = f"""
+            user_level={user_level}
+            growth_index={growth_index}
+            weak_section={weak_section}
+            weak_quiz={weak_quiz}
+            weakest_metric={weakest_metric}
+            present_growth={present_growth}
+            evidence_docs:
+            {evidence_text}
+            
+            작성 규칙:
+            1. 전체 톤은 밝음 70, 전문성 30 정도의 균형으로 작성한다.
+            2. 교육적이고 따뜻한 톤을 유지하되, 지나치게 감성적이거나 유아적인 표현은 피한다.
+            3. weak_section, weak_quiz, weakest_metric 중 최소 1개는 직접 언급한다.
+            4. 각 문장은 1~2문장 이내로 작성한다.
+            5. 사용자의 약점을 단정하거나 부정적으로 평가하지 않는다.
+            6. 아래와 같은 표현은 금지한다.
+               - "~이 부족합니다"
+               - "~이 부족한 것 같습니다"
+               - "~을 못하고 있습니다"
+               - "~이 약합니다"
+            7. summary_comment는 리포트의 첫인상 역할을 하도록, 밝고 안정감 있게 작성한다.
+            8. summary_comment는 "노력하고 있어요"처럼 평이한 표현보다,
+               "좋은 흐름이 보이고 있어요", "성장 방향이 점점 선명해지고 있어요",
+               "풀이 감각이 조금씩 안정적으로 자리잡고 있어요",
+               "이번 주에는 한 단계 더 정리된 풀이 흐름이 보이고 있어요"
+               같은 표현을 활용한다.
+            9. summary_comment는 응원하는 느낌은 주되, 과장된 칭찬이나 감탄사는 사용하지 않는다.
+            10. analysis_text는 사용자를 평가하는 문장이 아니라,
+                현재 반복되는 학습 패턴과 보완 포인트를 설명하는 문장으로 작성한다.
+            11. strategy_tip, recommended_action은 바로 실천 가능한 문장으로 작성한다.
+            12. 아래 JSON 키만 반환한다.
+            
+            좋은 예시:
+            {{
+              "summary_comment": "이번 주에는 풀이를 정리해가는 흐름이 더 또렷해지면서, 학습 방향이 한층 안정적으로 잡혀가고 있어요.",
+              "analysis_text": "STRATEGY 문단에서 풀이 전개를 정리하는 과정이 조금 흔들리는 패턴이 보여, 시간 복잡도 기준을 먼저 세우는 연습이 도움이 될 수 있어요.",
+              "strategy_tip": "문제를 읽은 뒤 바로 코드를 쓰기보다, 먼저 목표 시간복잡도를 한 줄로 적어보세요.",
+              "recommended_action": "이번 주에는 시간 복잡도 판단이 필요한 문제를 2개 골라 풀이 전에 O(...)를 먼저 써보세요."
+            }}
+            
+            나쁜 예시:
+            {{
+              "summary_comment": "이번 주에는 문제 해결 과정에서의 일관성 향상을 위해 노력하고 있어요.",
+              "analysis_text": "전략 섹션에서 약점을 보이고 있으며, 특히 시간 복잡도에 대한 이해가 부족한 것 같습니다.",
+              "strategy_tip": "더 열심히 하세요.",
+              "recommended_action": "복습하세요."
+            }}
+            
+            반환 형식:
+            {{
+              "summary_comment": "...",
+              "analysis_text": "...",
+              "strategy_tip": "...",
+              "recommended_action": "..."
+            }}
+            """.strip()
+
+
+        try:
+            response = await self.client.chat.completions.create(
+                model=self.model,
+                temperature=0.3,
+                max_tokens=400,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            )
+            raw = response.choices[0].message.content or ""
+            parsed = self._parse_json(raw)
+            print("[DEBUG] LLM base_url:", self.base_url)
+            print("[DEBUG] LLM model:", self.model)
+
+            return self._sanitize(parsed, fallback)
+        except Exception:
+            return fallback
+
+    def _parse_json(self, raw: str) -> dict[str, Any]:
+        raw = raw.strip()
+        try:
+            return json.loads(raw)
+        except Exception:
+            pass
+
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if not match:
+            return {}
+        try:
+            return json.loads(match.group(0))
+        except Exception:
+            return {}
+
+
+    def _sanitize(self, parsed: dict[str, Any], fallback: dict[str,str]) -> dict[str,str]:
+        keys = ["summary_comment", "analysis_text", "strategy_tip", "recommended_action"]
+        result: dict[str, str] = {}
+        for key in keys:
+            value = parsed.get(key)
+            if isinstance(value, str) and value.strip():
+                result[key] = value.strip()
+            else:
+                result[key] = fallback[key]
+
+        return result
+
+    # TODO : WARMUP이랑 STANDARD 멘트 다시 수정!
+    def _fallback_texts(self, *, report_mode:str, weakest_metric:str, weak_section:str, weak_quiz:str,) -> dict[str, str]:
+        if report_mode == "WARM_UP":
+            return {
+                "summary_comment": "",
+                "analysis_text": "",
+                "strategy_tip": "",
+                "recommended_action": "",
+            }
+        return {
+            "summary_comment": f"이번 주 핵심 보완 지표는 {weakest_metric}입니다.",
+            "analysis_text": f"{weak_section} 문단과 {weak_quiz} 유형에서 취약 패턴이 보입니다.",
+            "strategy_tip": f"{weak_section} 문단을 먼저 읽고 {weak_quiz} 유형을 집중 복습해보세요.",
+            "recommended_action": "문제 시작 전에 목표 시간복잡도를 정하고 풀이를 시작해보세요.",
+        }
+
+report_llm_service = ReportLlmService()

--- a/app/domain/report/report_rag_service.py
+++ b/app/domain/report/report_rag_service.py
@@ -1,0 +1,121 @@
+from typing import Any
+from qdrant_client.http import models
+
+from app.database.vector_db import vector_db
+from app.services.embedding_service import embedding_service
+
+class ReportRagService:
+    def __init__(self):
+        self.vector_db = vector_db
+        self.collection_name = "Algo_Concepts"
+        self.default_top_k = 3
+
+    async def retrieve_evidence(self, weak_section: str, weak_quiz: str, weakest_metric:str, user_level:str, top_k: int | None=None) -> list[dict[str,Any]]:
+        query_text = self._build_query_text(
+            weak_section=weak_section,
+            weak_quiz=weak_quiz,
+            weakest_metric=weakest_metric,
+            user_level=user_level,
+        )
+        query_vector = embedding_service.get_embedding(query_text)
+
+        query_filter = self._build_filter(weak_quiz)
+
+        try:
+            result = self.vector_db.client.query_points(
+                collection_name=self.collection_name,
+                query=query_vector,
+                query_filter=query_filter,
+                limit=top_k or self.default_top_k,
+                with_payload=True,
+            )
+        except Exception as e:
+            print(f"[DEBUG] report RAG retrieval failed: {e}")
+            return []
+
+        points = getattr(result, "points", []) or []
+
+        evidence_docs: list[dict[str, Any]] = []
+        seen_concepts: set[str] = set()
+
+        for rank, point in enumerate(points, start=1):
+            payload = point.payload or {}
+            concept = payload.get("concept", "UNKNOWN")
+
+            if concept in seen_concepts:
+                continue
+            seen_concepts.add(concept)
+
+            evidence_docs.append({
+                "rank": rank,
+                "score": round(point.score, 4) if getattr(point, "score", None) is not None else None,
+                "concept": concept,
+                "name_ko": payload.get("name_ko", ""),
+                "category": payload.get("category", ""),
+                "definition": payload.get("definition", ""),
+                "core_logic": payload.get("core_logic", ""),
+                "complexity_guide": payload.get("complexity_guide", ""),
+                "common_mistakes": payload.get("common_mistakes", []),
+                "check_points": payload.get("check_points", []),
+            })
+
+        return evidence_docs
+
+    def _build_query_text(self, weak_section: str, weak_quiz: str, weakest_metric: str, user_level:str) -> str:
+        # TODO : 이거 3개 뭐임?
+        section_hint = self._section_hint(weak_section)
+        quiz_hint = self._quiz_hint(weak_quiz)
+        metric_hint = self._metric_hint(weakest_metric)
+
+        return(
+            f"user_level={user_level}\n"
+            f"weak_section={weak_section}\n"
+            f"weak_quiz={weak_quiz}\n"
+            f"weakest_metric={weakest_metric}\n"
+            f"section_hint={section_hint}\n"
+            f"quiz_hint={quiz_hint}\n"
+            f"metric_hint={metric_hint}\n"
+            "goal=근거 기반 학습 전략 추천"
+        )
+
+    def _section_hint(self, weak_section: str) -> str:
+        mapping={
+            "BACKGROUND": "문제 배경과 상황 이해",
+            "GOAL": "문제 목표와 요구사항 파악",
+            "RULE": "핵심 규칙과 로직 정리",
+            "CONSTRAINT": "입력 범위, 시간 복잡도, 메모리 제한 확인",
+        }
+        return mapping.get(weak_section, weak_section)
+
+    def _quiz_hint(self, weak_quiz:str) -> str:
+        mapping={
+            "ALGORITHM": "알고리즘 선택과 적용 근거",
+            "LOGIC_CHECK": "조건 분기, 예외 처리, 반례 검증",
+            "DATA_STRUCTURE": "적절한 자료구조 선택",
+            "TIME_COMPLEXITY": "N 범위와 시간 복잡도 계산"
+        }
+        return mapping.get(weak_quiz, weak_quiz)
+
+    def _metric_hint(self, weakest_metric: str) -> str:
+        mapping = {
+            "accuracy": "정답률과 요구사항 반영 정확도",
+            "independence": "힌트 의존도와 자가 해결력",
+            "efficiency": "풀이 속도와 시간 복잡도 적합성",
+            "consistency": "학습 지속성과 반복 훈련",
+        }
+        return mapping.get(weakest_metric, weakest_metric)
+
+    # TODO: 이거 뭐임?
+    def _build_filter(self, weak_quiz:str) -> models.Filter | None:
+        if weak_quiz == "DATA_STRUCTURE":
+            return models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="category",
+                        match=models.MatchValue(value="DATA_STRUCTURE"),
+                    )
+                ]
+            )
+        return None
+
+report_rag_service = ReportRagService()

--- a/app/domain/report/report_router.py
+++ b/app/domain/report/report_router.py
@@ -7,7 +7,7 @@ from app.domain.report.report_service import report_service
 router = APIRouter()
 
 @router.post("", response_model=CommonResponse[ReportResponseData])
-async def genearte_report(request: ReportRequest):
+async def generate_report(request: ReportRequest):
     data = await report_service.generate_report(request)
     return CommonResponse.success_response(message="OK", data=data)
 

--- a/app/domain/report/report_schemas.py
+++ b/app/domain/report/report_schemas.py
@@ -8,16 +8,16 @@ class ChatbotMessage(BaseModel):
     id: int
     user_id: int
     problem_id: int
-    ai_message: str
-    user_message: str
+    ai_message: str | None = None
+    user_message: str | None = None
     node: str
     send_at: str
 
 class RawMetrics(BaseModel):
     chatbot_msg_history: list[ChatbotMessage] = Field(default_factory=list)
     total_chatbot_requests: int = 0
-    total_summary_complete_sec: int = 0
-    quests_clears_weekly: int = 0
+    solve_duration_sec: int = 0
+    solved_problems_weekly : int = 0
 
 class ReportRequest(BaseModel):
     user_id: int

--- a/app/domain/report/report_service.py
+++ b/app/domain/report/report_service.py
@@ -2,6 +2,8 @@ import math
 from collections import defaultdict
 
 from app.common.exceptions.custom_exception import DependencyNotReadyException
+from app.domain.report.report_llm_service import report_llm_service
+from app.domain.report.report_rag_service import report_rag_service
 from app.domain.report.report_schemas import (
     FutureRoadmap,
     PastDiagnosis,
@@ -15,6 +17,7 @@ from app.domain.report.report_schemas import (
 class ReportService:
     WARMUP_THRESHOLD = 3
 
+    # TODO: LEVEL_BASE_LINE이랑 ROADMAP_BY_LEVEL => 이대로 할 것인지,,, 아니면 지표 바꿀 것인지 고민
     LEVEL_BASELINE = {
         "newbie": {"independence": 65.0, "consistency": 50.0, "efficiency": 65.0},
         "pupil": {"independence": 72.0, "consistency": 60.0, "efficiency": 72.0},
@@ -29,10 +32,10 @@ class ReportService:
 
 
     async def generate_report(self, req: ReportRequest) -> ReportResponseData:
-        if req.raw_metrics.quests_clears_weekly < self.WARMUP_THRESHOLD:
+        if req.raw_metrics.solved_problems_weekly < self.WARMUP_THRESHOLD:
             report = self._warmup_report(req)
         else:
-            report = self._standard_report(req)
+            report = await self._standard_report(req)
 
         return ReportResponseData(
             user_id=req.user_id,
@@ -48,7 +51,7 @@ class ReportService:
         independence = base["independence"]
         efficiency = (
             self._calculate_efficiency(req)
-            if req.raw_metrics.quests_clears_weekly > 0
+            if req.raw_metrics.solved_problems_weekly  > 0
             else base["efficiency"]
         )
         consistency = base["consistency"]
@@ -62,15 +65,12 @@ class ReportService:
 
         weak_section = self._max_key(req.paragraph_fail_stats, default="UNKNOWN")
 
-
-        # TODO: 추후 RAG + llm 도입하면 수정할 예정
-        # summary_comment, analysis_text, metrics_analysis_comment, strategy_tip
-
+        # TODO : 수정 예정
         return ReportBody(
             report_mode="WARM_UP",
             summary=ReportSummary(
                 growth_index=growth_index,
-                user_type="new_challenger",
+                user_type="잠재력 폭발 아기 코알라",
                 summary_comment="좋은 출발이에요. 아직 데이터가 적어 이번 주는 가벼운 온보딩 리포트로 안내드릴게요!",
             ),
             past_diagnosis=PastDiagnosis(
@@ -94,7 +94,7 @@ class ReportService:
             ),
         )
 
-    def _standard_report(self, req: ReportRequest) -> ReportBody:
+    async def _standard_report(self, req: ReportRequest) -> ReportBody:
         accuracy = self._calculate_accuracy(req)
         independence = self._calculate_independence(req)
         efficiency = self._calculate_efficiency(req)
@@ -116,24 +116,44 @@ class ReportService:
             consistency=consistency,
         )
 
-        # TODO: RAG 조회 추가 + 424 에러 추가 + llm text 추가 예정
+        evidence_docs = await report_rag_service.retrieve_evidence(
+            weak_section=weak_section,
+            weak_quiz=weak_quiz,
+            weakest_metric=weakest_metric,
+            user_level=req.user_level,
+            top_k=3
+        )
 
+        if not evidence_docs:
+            raise DependencyNotReadyException()
 
-        # TODO : llm text로 변경 예정
+        llm_text = await report_llm_service.generate_sections(
+            user_level=req.user_level,
+            report_mode="STANDARD",
+            growth_index=growth_index,
+            weak_section=weak_section,
+            weak_quiz=weak_quiz,
+            weakest_metric=weakest_metric,
+            present_growth={
+                "accuracy": accuracy,
+                "independence": independence,
+                "efficiency": efficiency,
+                "consistency": consistency,
+            },
+            evidence_docs=evidence_docs
+        )
+
         return ReportBody(
             report_mode="STANDARD",
             summary=ReportSummary(
                 growth_index=growth_index,
                 user_type=self._user_type(growth_index),
-                summary_comment=f"이번 주 핵심 보완 지표는 {weakest_metric}입니다.",
+                summary_comment=llm_text["summary_comment"],
             ),
             past_diagnosis=PastDiagnosis(
                 weak_section=weak_section,
                 paragraph_fail_stats=req.paragraph_fail_stats,
-                analysis_text=(
-                    f"{weak_section} 문단에서 오답이 집중되었고,"
-                    f"퀴즈 기준으로는 {weak_quiz} 축이 취약합니다."
-                ),
+                analysis_text=llm_text["analysis_text"],
             ),
             present_growth=PresentGrowth(
                 accuracy=accuracy,
@@ -144,12 +164,9 @@ class ReportService:
                 is_imputed=False,
             ),
             future_roadmap=FutureRoadmap(
-                strategy_tip=(
-                    f"{weak_section} 문단 우선 확인 + {weak_quiz} 유형 집중 훈련으로"
-                    f"{weakest_metric} 지표를 먼저 개선하세요."
-                ),
-                recommended_action=self._recommended_action(weakest_metric),
-            )
+                strategy_tip=llm_text["strategy_tip"],
+                recommended_action=llm_text["recommended_action"],
+            ),
         )
 
 
@@ -175,7 +192,7 @@ class ReportService:
             ratio = quality_sum / len(first_by_node)
             return round(self._clamp(60 + ratio * 40, 0, 100),1)
 
-        clears = req.raw_metrics.quests_clears_weekly
+        clears = req.raw_metrics.solved_problems_weekly
         fails = sum(req.paragraph_fail_stats.values())
         denom = clears + fails
 
@@ -209,8 +226,8 @@ class ReportService:
         return round(self._clamp(100 - penalty, 0, 100), 1)
 
     def _calculate_efficiency(self, req:ReportRequest) -> float:
-        clears = max(req.raw_metrics.quests_clears_weekly, 1)
-        sec_per_quest = req.raw_metrics.total_summary_complete_sec / clears
+        clears = max(req.raw_metrics.solved_problems_weekly , 1)
+        sec_per_quest = req.raw_metrics.solve_duration_sec / clears
 
         if sec_per_quest <= 300:
             return 95.0
@@ -224,7 +241,7 @@ class ReportService:
 
 
     def _calculate_consistency(self, req: ReportRequest) -> float:
-        clears = req.raw_metrics.quests_clears_weekly
+        clears = req.raw_metrics.solved_problems_weekly
         return round(self._clamp((clears/14) * 100, 0, 100),1)
 
     def _growth_index(self, *, accuracy:float, independence:float, efficiency:float, consistency:float) -> float:
@@ -260,36 +277,38 @@ class ReportService:
         }
         return min(metrics, key=metrics.get)
 
-    # TODO : 여기 이름 바꾸기
     def _user_type(self, growth_index: float) -> str:
         if growth_index >= 85:
-            return "날카로운 매"
+            return "숲을 지배한 코알라"
         if growth_index >= 70:
-            return "steady_climber"
+            return "뿌리 깊은 코알라"
         if growth_index >= 55:
-            return "growing_solver"
-        return "new_challenger"
+            return "번개 맞은 코알라"
+        return "잠재력 폭발 아기 코알라"
 
-    # TODO: 여기 멘트 변경?
+    # TODO: 여기 멘트 변경
     def _metrics_comment(self, weakest_metric:str) -> str:
         mapping = {
-            "accuracy": "제약사항 확인 후 풀이 시작 습관을 강화하세요.",
-            "independence": "힌트 요청 전 15분 자가 시도 루틴을 적용하세요.",
-            "efficiency": "목표 시간복잡도를 먼저 정하고 풀이를 선택하세요.",
-            "consistency": "짧은 일일 학습 루틴으로 주간 연속성을 높이세요.",
+            "accuracy": "유칼립투스 잎을 꼼꼼히 고르듯, 문제 속 제약사항(CONSTRAINT)을 한 번 더 살펴보면 실수가 줄어들 거예요.",
+            "independence": "스스로 길을 찾는 코알라가 더 멀리 갈 수 있어요. 힌트를 보기 전 딱 5분만 더 고민해볼까요?",
+            "efficiency": "속도라는 날개를 달아볼 시간! 코드를 짜기 전, 이 문제에 가장 어울리는 시간복잡도가 무엇일지 먼저 그려보세요.",
+            "consistency": "나무 위에서 매일 조금씩 쉬어가듯, 짧더라도 매일 학습하는 습관이 예진님의 가장 큰 무기가 될 거예요.",
         }
-        return mapping.get(weakest_metric, "4대 지표의 균형을 유지하세요.")
+        return mapping.get(
+            weakest_metric,
+            "모든 지표가 골고루 성장하고 있어요! 이 균형을 유지하며 다음 단계로 나아가봐요."
+        )
 
+    # 좀 더 전문적인 버전,,
+    # def _metrics_comment(self, weakest_metric:str) -> str:
+    #     mapping = {
+    #         "accuracy": "문제의 요구사항을 로직으로 전환하는 과정에서 미세한 누수가 발생하고 있습니다. 제약 조건(Constraint)의 엄격한 준수가 필요합니다.",
+    #         "independence": "문제 해결 과정에서 외부 의존성이 높게 측정되었습니다. 스스로 로직을 설계하고 검증하는 완결성 강화가 시급합니다.",
+    #         "efficiency": "구현의 정확성에 비해 자원 활용 효율이 아쉽습니다. 알고리즘 선택 전, 데이터 규모에 따른 최적 복잡도를 산정하는 습관이 필요합니다.",
+    #         "consistency": "학습 데이터의 밀도가 불규칙합니다. 실력의 정체기를 돌파하기 위해서는 일정한 리듬의 규칙적인 훈련 로그가 뒷받침되어야 합니다.",
+    #     }
+    # return mapping.get(weakest_metric, "전반적인 지표가 균형 있게 성장 중입니다. 현재의 학습 템포를 유지하며 난이도를 점진적으로 높여보세요.")
 
-    # TODO: llm text 기능 추가되면 삭제
-    def _recommended_action(self, weakest_metric: str) -> str:
-        mapping={
-            "accuracy": "문제마다 CONSTRAINT를 먼저 표시하고 풀이를 시작하세요.",
-            "independence": "한 문제당 힌트 없이 1회 완주 후 질문하세요.",
-            "efficiency": "N 범위를 기준으로 O(...) 목표를 먼저 선언하세요.",
-            "consistency": "하루 20분씩 주 5회 고정 학습 슬롯을 잡으세요.",
-        }
-        return mapping.get(weakest_metric, "취약 지표 중심으로 다음 주 계획을 세우세요.")
 
     def _clamp(self, value:float, lo:float, hi:float) -> float:
         return max(lo, min(hi, value))


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #18
- #27
- #28

## 📝 작업 내용
- 분석 리포트 생성 엔드포인트 및 요청/응답 스키마를 추가 (`report_router.py`, `report_schemas.py`)
- `STANDARD` 모드에서 `Algo_Concepts` 컬렉션 기반 RAG 근거 조회 후 Qwen 기반 LLM으로 리포트 문구를 생성하도록 연동(`report_rag_service.py`, `report_llm_service.py`)
- 리포트 문구 생성 시 JSON 출력 구조를 고정하고, 파싱 실패 시 fallback 문구를 반환하도록 보완
- Qdrant 조회 오타, LLM 호출 인자 오타, 예외 처리(424) 등 리포트 경로에서 발생하던 오류를 수정
- ai_message = null 처리 가능하도록 스키마 수정

## 📸 스크린샷 (선택)


## 📢 참고 사항
- 분석 리포트는 협업 필터링을 사용하지 않고, 문제 추천 API에만 협업 필터링을 유지
- 리포트는 `규칙 기반 지표 계산 + RAG 근거 검색 + LLM 서술 생성` 구조로 구성
- 현재 리포트 문구 생성 모델은 Qwen 기반이며, 실패 시 fallback 문구를 반환
- 스키마 필드명을 아래와 같이 정리했습니다.
  - `quests_clears_weekly` -> `solved_problems_weekly`
  - `total_summary_complete_sec` -> `solve_duration_sec`
