### PR TITLE
[chore] analysis 배포를 ECR + CodeDeploy 방식으로 전환

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,129 +1,143 @@
-# .github/workflows/cd.yml
 name: ai-cd
 
 on:
   push:
-    branches: [main, dev, chore/cicd]
-  workflow_dispatch:
+    branches: [chore/v2-chatai-cicd]
+  workflow_dispatch: {}
 
 permissions:
   contents: read
   actions: read
 
+concurrency:
+  group: ai-cd-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  ci:
     uses: ./.github/workflows/ci.yml
+    with:
+      publish_image: true
     secrets: inherit
 
   deploy:
-    needs: build
+    needs: ci
     runs-on: ubuntu-latest
     env:
       IS_PROD: ${{ github.ref_name == 'main' }}
-      IS_DEV_BRANCH: ${{ github.ref_name != 'main' }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      AWS_ACCESS_KEY_ID: ${{ github.ref_name != 'main' && secrets.AWS_ACCESS_KEY_ID_DEV || secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ github.ref_name != 'main' && secrets.AWS_SECRET_ACCESS_KEY_DEV || secrets.AWS_SECRET_ACCESS_KEY }}
-      AI_INSTANCE_ID: ${{ github.ref_name != 'main' && secrets.AI_INSTANCE_ID_DEV || secrets.AI_INSTANCE_ID }}
-      AI_ENV: ${{ github.ref_name != 'main' && secrets.AI_ENV_DEV || secrets.AI_ENV }}
+      RAW_ENV_CONFIG: ${{ github.ref_name == 'main' && secrets.ENV_PROD || secrets.ENV_DEV }}
 
     steps:
-      # 1) AWS 인증
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      # 2) SSM 배포 실행 (.env 생성 + deploy.sh 실행)
-      - name: Trigger deploy via SSM (create env + run deploy)
+      - name: Load environment config
         run: |
-          set -e
-
-          ARTIFACT_NAME="ai-source-${{ github.sha }}"
-          ENV_PATH="/home/ubuntu/analysis/shared/.env"
-
-          COMMAND_ID=$(
-            aws ssm send-command \
-              --instance-ids "${{ env.AI_INSTANCE_ID }}" \
-              --document-name "AWS-RunShellScript" \
-              --region "${{ env.AWS_REGION }}" \
-              --parameters commands="[
-                \"set -e\",
-                \"mkdir -p /home/ubuntu/analysis/shared\",
-                \"cat > ${ENV_PATH} << 'EOF'\",
-                \"${{ env.AI_ENV }}\",
-                \"EOF\",
-                \"chmod 600 ${ENV_PATH}\",
-                \"chown ubuntu:ubuntu ${ENV_PATH}\",
-                \"bash /home/ubuntu/analysis/deploy.sh '${{ secrets.GH_TOKEN }}' '${{ github.repository }}' '${{ github.run_id }}' '${ARTIFACT_NAME}' '${ENV_PATH}'\"
-              ]" \
-              --query "Command.CommandId" --output text
-          )
-
-          echo "🚀 배포 명령 전송됨 (ID: $COMMAND_ID)"
-
-          # 상태 추적 루프
-          while true; do
-            STATUS=$(aws ssm list-commands \
-              --command-id "$COMMAND_ID" \
-              --region "${{ env.AWS_REGION }}" \
-              --query "Commands[0].Status" --output text)
-
-            echo "현재 배포 상태: $STATUS"
-
-            if [[ "$STATUS" != "InProgress" && "$STATUS" != "Pending" ]]; then
-              break
-            fi
-
-            sleep 10
-          done
-
-          # stdout 출력
-          echo "=== ✅ stdout (정상 로그) ==="
-          aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "${{ env.AI_INSTANCE_ID }}" \
-            --region "${{ env.AWS_REGION }}" \
-            --query "StandardOutputContent" --output text
-
-          # stderr 출력
-          echo "=== ❌ stderr (에러 로그) ==="
-          aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" \
-            --instance-id "${{ env.AI_INSTANCE_ID }}" \
-            --region "${{ env.AWS_REGION }}" \
-            --query "StandardErrorContent" --output text
-
-          # 실패 시 워크플로우 실패 처리
-          if [ "$STATUS" != "Success" ]; then
-            echo "❌ 배포 최종 실패"
+          set -euo pipefail
+          if [ -z "${RAW_ENV_CONFIG:-}" ]; then
+            echo "ENV_DEV / ENV_PROD secret is empty"
             exit 1
           fi
 
-          echo "✅ 배포 최종 성공"
+          while IFS= read -r line; do
+            line="${line%$'\r'}"
+            [ -z "$line" ] && continue
+            case "$line" in \#*) continue ;; esac
 
-      # 3) Discord 알림 (항상 실행)
+            key="${line%%=*}"
+            value="${line#*=}"
+
+            if ! [[ "$key" =~ ^[A-Z0-9_]+$ ]]; then
+              echo "Invalid key in ENV config: $key"
+              exit 1
+            fi
+
+            echo "$key=$value" >> "$GITHUB_ENV"
+          done <<< "$RAW_ENV_CONFIG"
+
+      - name: Validate required vars
+        run: |
+          set -euo pipefail
+          for k in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION CODEDEPLOY_APP CODEDEPLOY_GROUP DEPLOY_BUCKET DEPLOY_KEY ECR_REGISTRY ECR_REPO DISCORD_WEBHOOK; do
+            if [ -z "${!k:-}" ]; then
+              echo "Missing required var: $k"
+              exit 1
+            fi
+          done
+
+      - name: Detect CodeDeploy bundle changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            codedeploy:
+              - 'codedeploy/**'
+
+      - name: Render deployment env for instance
+        run: |
+          set -euo pipefail
+
+          if [ "${IS_PROD}" = "true" ]; then
+            DEPLOY_TAG="prod"
+          else
+            DEPLOY_TAG="dev"
+          fi
+
+          mkdir -p codedeploy
+          printf "%s\n" \
+            "AWS_REGION=${AWS_REGION}" \
+            "ECR_REGISTRY=${ECR_REGISTRY}" \
+            "ECR_REPO=${ECR_REPO}" \
+            "DEPLOY_TAG=${DEPLOY_TAG}" \
+            "CONTAINER_NAME=analysis_api_server" \
+            "HOST_PORT=8010" \
+            "APP_PORT=8010" \
+            "HEALTH_PATH=/" \
+            "SSM_PARAM_NAME=analysis-core" \
+            > codedeploy/deploy.env
+
+      - name: Upload bundle to S3
+        if: steps.changes.outputs.codedeploy == 'true' || github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+
+          cd codedeploy
+          zip -r /tmp/codoc-deploy.zip .
+          aws s3 cp /tmp/codoc-deploy.zip "s3://${DEPLOY_BUCKET}/${DEPLOY_KEY}"
+
+      - name: Create CodeDeploy deployment
+        run: |
+          set -euo pipefail
+
+          DEPLOYMENT_ID=$(aws deploy create-deployment \
+            --application-name "${CODEDEPLOY_APP}" \
+            --deployment-group-name "${CODEDEPLOY_GROUP}" \
+            --revision "revisionType=S3,s3Location={bucket=${DEPLOY_BUCKET},key=${DEPLOY_KEY},bundleType=zip}" \
+            --query 'deploymentId' \
+            --output text)
+
+          echo "DEPLOYMENT_ID=${DEPLOYMENT_ID}" >> "$GITHUB_ENV"
+          echo "Created deployment: ${DEPLOYMENT_ID}"
+
+      - name: Wait deployment result
+        run: |
+          set -euo pipefail
+          aws deploy wait deployment-successful --deployment-id "${DEPLOYMENT_ID}"
+
       - name: Notify Discord (always)
         if: always()
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ github.ref_name }}"
-          EVENT="${{ github.event_name }}"
           ACTOR="${{ github.actor }}"
-          SHA="${{ github.sha }}"
           COMMIT_MSG="${{ github.event.head_commit.message }}"
 
           if [ -z "$COMMIT_MSG" ]; then
             COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"
           fi
 
-          # JSON 안전 이스케이프 처리
-          COMMIT_MSG_ESCAPED=$(printf '%s' "$COMMIT_MSG" | sed \
-            's/\\/\\\\/g; s/\"/\\\"/g; :a;N;$!ba;s/\n/\\n/g')
+          COMMIT_MSG_ESCAPED=$(printf '%s' "$COMMIT_MSG" | sed 's/\\/\\\\/g; s/\"/\\\"/g; :a;N;$!ba;s/\n/\\n/g')
 
-          # 상태 분기
           if [ "${{ job.status }}" = "success" ]; then
             STATUS="✅ 성공"
             COLOR="65280"
@@ -132,7 +146,8 @@ jobs:
             COLOR="16711680"
           fi
 
-          # Discord Webhook 전송
+          DEPLOYMENT_ID_MSG="${DEPLOYMENT_ID:-N/A}"
+
           curl -X POST -H "Content-Type: application/json" \
           -d "{
             \"embeds\": [{
@@ -141,8 +156,9 @@ jobs:
               \"color\": ${COLOR},
               \"fields\": [
                 {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG_ESCAPED}\"},
+                {\"name\": \"Deployment ID\", \"value\": \"${DEPLOYMENT_ID_MSG}\"},
                 {\"name\": \"배포 로그\", \"value\": \"${RUN_URL}\"}
               ]
             }]
           }" \
-          ${{ secrets.DISCORD_WEBHOOK }}
+          "${DISCORD_WEBHOOK}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,17 @@
 name: ai-ci
 
 on:
-  # pull_request:
-  #   branches: [dev, main]
-  # push:
-  #   branches: [dev]
-  workflow_dispatch: {}
   workflow_call:
+    inputs:
+      publish_image:
+        required: false
+        type: boolean
+        default: false
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main, chore/v2-chatai-cicd]
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -20,11 +25,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 체크아웃
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 파이썬 설정
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -34,79 +37,28 @@ jobs:
             requirements.txt
             requirements-dev.txt
 
-      # 의존성 설치
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-          pip install ruff build
-
-      # # 린트
-      # - name: Lint
-      #   run: ruff check .
-
-      # # 포맷 체크
-      # - name: Format Check
-      #   run: ruff format --check .
-
-      # # 테스트
-      # - name: Tests
-      #   run: |
-      #     if python -c "import importlib.util; import sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)"; then
-      #       pytest -q
-      #     else
-      #       echo "pytest not installed. Skipping tests."
-      #     fi
-
-      # 의존성 감사(warn-only)
-      - name: Dependency Audit
-        run: |
           pip install pip-audit
-          pip-audit -l || true
 
-      # # 패키징(main만)
-      # - name: Build
-      #   if: github.event_name == 'push' && github.ref == 'refs/heads/chore/ci-cd'
-      #   run: |
-      #     python -m build
-      #     ls -al dist
-
-      # # 아티팩트 업로드(main만)
-      # - name: Upload Artifact
-      #   if: github.event_name == 'push' && github.ref == 'refs/heads/chore/ci-cd'
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ai-dist-${{ github.sha }}
-      #     path: dist/*
-      #     if-no-files-found: error
-      #     retention-days: 7
-
-      # 6. 소스 아티팩트 업로드
-      - name: Upload source artifact
-      #  if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ai-source-${{ github.sha }}
-          path: ./
-          retention-days: 7
+      - name: Dependency Audit
+        run: pip-audit -l || true
 
       - name: Notify Discord (always)
-        if: always()
+        if: always() && github.event_name != 'workflow_call'
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ github.ref_name }}"
-          EVENT="${{ github.event_name }}"
           ACTOR="${{ github.actor }}"
-          SHA="${{ github.sha }}"
           COMMIT_MSG="${{ github.event.head_commit.message }}"
 
           if [ -z "$COMMIT_MSG" ]; then
             COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"
           fi
 
-          # 역슬래시, 큰따옴표, 그리고 줄바꿈(\n)을 JSON 규격에 맞게 이스케이프 처리
           COMMIT_MSG_ESCAPED=$(printf '%s' "$COMMIT_MSG" | sed 's/\\/\\\\/g; s/\"/\\\"/g; :a;N;$!ba;s/\n/\\n/g')
 
           if [ "${{ job.status }}" = "success" ]; then
@@ -130,3 +82,78 @@ jobs:
             }]
           }" \
           ${{ secrets.DISCORD_WEBHOOK }}
+
+  docker_publish:
+    needs: verify
+    if: github.event_name == 'push' || (github.event_name == 'workflow_call' && inputs.publish_image)
+    runs-on: ubuntu-latest
+    env:
+      IS_PROD: ${{ github.ref_name == 'main' }}
+      RAW_ENV_CONFIG: ${{ github.ref_name == 'main' && secrets.ENV_PROD || secrets.ENV_DEV }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load environment config
+        run: |
+          set -euo pipefail
+          if [ -z "${RAW_ENV_CONFIG:-}" ]; then
+            echo "ENV_DEV / ENV_PROD secret is empty"
+            exit 1
+          fi
+
+          while IFS= read -r line; do
+            line="${line%$'\r'}"
+            [ -z "$line" ] && continue
+            case "$line" in \#*) continue ;; esac
+
+            key="${line%%=*}"
+            value="${line#*=}"
+
+            if ! [[ "$key" =~ ^[A-Z0-9_]+$ ]]; then
+              echo "Invalid key in ENV config: $key"
+              exit 1
+            fi
+
+            echo "$key=$value" >> "$GITHUB_ENV"
+          done <<< "$RAW_ENV_CONFIG"
+
+      - name: Validate required vars
+        run: |
+          set -euo pipefail
+          for k in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION ECR_REGISTRY ECR_REPO; do
+            if [ -z "${!k:-}" ]; then
+              echo "Missing required var: $k"
+              exit 1
+            fi
+          done
+
+      - name: Build and Push Docker image
+        run: |
+          set -euo pipefail
+
+          if [ "${IS_PROD}" = "true" ]; then
+            TAG_ALIAS="prod"
+          else
+            TAG_ALIAS="dev"
+          fi
+
+          IMAGE_URI="${ECR_REGISTRY}/${ECR_REPO}"
+          aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+          docker build \
+            -t "${IMAGE_URI}:${GITHUB_SHA}" \
+            -t "${IMAGE_URI}:${TAG_ALIAS}" \
+            .
+
+          docker push "${IMAGE_URI}:${GITHUB_SHA}"
+          docker push "${IMAGE_URI}:${TAG_ALIAS}"
+
+          echo "IMAGE_URI=${IMAGE_URI}" >> "$GITHUB_ENV"
+          echo "TAG_ALIAS=${TAG_ALIAS}" >> "$GITHUB_ENV"
+
+      - name: Summary
+        run: |
+          echo "Pushed image: ${IMAGE_URI}:${GITHUB_SHA}"
+          echo "Pushed image: ${IMAGE_URI}:${TAG_ALIAS}"

--- a/codedeploy/README.md
+++ b/codedeploy/README.md
@@ -1,0 +1,25 @@
+# CodeDeploy bundle
+
+This folder is zipped and uploaded to S3, then used by AWS CodeDeploy.
+
+## Required on target EC2 (AMI)
+
+1. CodeDeploy agent installed and running
+2. Docker installed and runnable by `ubuntu`
+3. IAM role includes:
+   - AmazonEC2RoleforAWSCodeDeploy
+   - AmazonEC2ContainerRegistryReadOnly
+4. `/home/ubuntu/analysis/shared/.env` (optional app env)
+5. `/home/ubuntu/analysis/shared/deploy.env` is created by CD workflow from secrets
+
+## Local test
+
+```bash
+cd codedeploy
+zip -r /tmp/codoc-deploy.zip .
+aws s3 cp /tmp/codoc-deploy.zip s3://<bucket>/<key>
+aws deploy create-deployment \
+  --application-name <app> \
+  --deployment-group-name <group> \
+  --revision "revisionType=S3,s3Location={bucket=<bucket>,key=<key>,bundleType=zip}"
+```

--- a/codedeploy/appspec.yml
+++ b/codedeploy/appspec.yml
@@ -1,0 +1,24 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ubuntu/analysis/codedeploy-bundle
+permissions:
+  - object: /home/ubuntu/analysis/codedeploy-bundle/scripts
+    pattern: "**"
+    owner: ubuntu
+    group: ubuntu
+    mode: 755
+hooks:
+  ApplicationStop:
+    - location: scripts/stop_container.sh
+      timeout: 120
+      runas: ubuntu
+  AfterInstall:
+    - location: scripts/deploy_container.sh
+      timeout: 900
+      runas: ubuntu
+  ValidateService:
+    - location: scripts/validate_service.sh
+      timeout: 180
+      runas: ubuntu

--- a/codedeploy/scripts/deploy_container.sh
+++ b/codedeploy/scripts/deploy_container.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_FILE_PRIMARY="/home/ubuntu/analysis/codedeploy-bundle/deploy.env"
+CONFIG_FILE_FALLBACK="/home/ubuntu/analysis/shared/deploy.env"
+APP_ENV_FILE_PRIMARY="/home/ubuntu/app/.env"
+APP_ENV_FILE_FALLBACK="/home/ubuntu/analysis/shared/.env"
+
+if [ -f "$CONFIG_FILE_PRIMARY" ]; then
+  CONFIG_FILE="$CONFIG_FILE_PRIMARY"
+elif [ -f "$CONFIG_FILE_FALLBACK" ]; then
+  CONFIG_FILE="$CONFIG_FILE_FALLBACK"
+else
+  echo "[deploy] missing config file"
+  echo "[deploy] checked: $CONFIG_FILE_PRIMARY and $CONFIG_FILE_FALLBACK"
+  echo "[deploy] required keys: ECR_REGISTRY, ECR_REPO (optional: DEPLOY_TAG, CONTAINER_NAME, HOST_PORT, APP_PORT, AWS_REGION)"
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+
+AWS_REGION="${AWS_REGION:-ap-northeast-2}"
+DEPLOY_TAG="${DEPLOY_TAG:-dev}"
+CONTAINER_NAME="${CONTAINER_NAME:-analysis_ai}"
+HOST_PORT="${HOST_PORT:-8000}"
+APP_PORT="${APP_PORT:-8000}"
+SSM_PARAM_NAME="${SSM_PARAM_NAME:-}"
+
+: "${ECR_REGISTRY:?ECR_REGISTRY is required in $CONFIG_FILE}"
+: "${ECR_REPO:?ECR_REPO is required in $CONFIG_FILE}"
+
+IMAGE_URI="${ECR_REGISTRY}/${ECR_REPO}:${DEPLOY_TAG}"
+
+echo "[deploy] image: ${IMAGE_URI}"
+
+aws ecr get-login-password --region "$AWS_REGION" | \
+  docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+docker pull "$IMAGE_URI"
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+# Refresh runtime env from Parameter Store on every deployment.
+if [ -n "$SSM_PARAM_NAME" ]; then
+  mkdir -p "$(dirname "$APP_ENV_FILE_PRIMARY")"
+  aws ssm get-parameter \
+    --name "$SSM_PARAM_NAME" \
+    --with-decryption \
+    --query "Parameter.Value" \
+    --output text \
+    --region "$AWS_REGION" \
+    > "$APP_ENV_FILE_PRIMARY"
+fi
+
+DOCKER_ENV_ARGS=()
+if [ -f "$APP_ENV_FILE_PRIMARY" ]; then
+  DOCKER_ENV_ARGS+=(--env-file "$APP_ENV_FILE_PRIMARY")
+elif [ -f "$APP_ENV_FILE_FALLBACK" ]; then
+  DOCKER_ENV_ARGS+=(--env-file "$APP_ENV_FILE_FALLBACK")
+fi
+
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  --restart unless-stopped \
+  -p "${HOST_PORT}:${APP_PORT}" \
+  "${DOCKER_ENV_ARGS[@]}" \
+  "$IMAGE_URI"
+
+docker image prune -f >/dev/null 2>&1 || true

--- a/codedeploy/scripts/stop_container.sh
+++ b/codedeploy/scripts/stop_container.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_FILE_PRIMARY="/home/ubuntu/analysis/codedeploy-bundle/deploy.env"
+CONFIG_FILE_FALLBACK="/home/ubuntu/analysis/shared/deploy.env"
+CONTAINER_NAME="analysis_ai"
+
+if [ -f "$CONFIG_FILE_PRIMARY" ]; then
+  CONFIG_FILE="$CONFIG_FILE_PRIMARY"
+elif [ -f "$CONFIG_FILE_FALLBACK" ]; then
+  CONFIG_FILE="$CONFIG_FILE_FALLBACK"
+else
+  CONFIG_FILE=""
+fi
+
+if [ -n "$CONFIG_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+fi
+
+CONTAINER_NAME="${CONTAINER_NAME:-analysis_ai}"
+
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true

--- a/codedeploy/scripts/validate_service.sh
+++ b/codedeploy/scripts/validate_service.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_FILE_PRIMARY="/home/ubuntu/analysis/codedeploy-bundle/deploy.env"
+CONFIG_FILE_FALLBACK="/home/ubuntu/analysis/shared/deploy.env"
+HOST_PORT="8000"
+HEALTH_PATH="/"
+
+if [ -f "$CONFIG_FILE_PRIMARY" ]; then
+  CONFIG_FILE="$CONFIG_FILE_PRIMARY"
+elif [ -f "$CONFIG_FILE_FALLBACK" ]; then
+  CONFIG_FILE="$CONFIG_FILE_FALLBACK"
+else
+  CONFIG_FILE=""
+fi
+
+if [ -n "$CONFIG_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
+fi
+
+HOST_PORT="${HOST_PORT:-8000}"
+HEALTH_PATH="${HEALTH_PATH:-/}"
+HEALTH_URL="http://localhost:${HOST_PORT}${HEALTH_PATH}"
+
+for i in {1..20}; do
+  if curl -fsS "$HEALTH_URL" | grep -qi "healthy"; then
+    echo "[deploy] health check passed: $HEALTH_URL"
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "[deploy] health check failed: $HEALTH_URL"
+exit 1


### PR DESCRIPTION
## 📝 작업 내용
- 기존 SSH/SCP 중심 배포 흐름을 ECR 이미지 기반 + CodeDeploy 배포 방식으로 전환했습니다.
- CI 워크플로에서 Docker 이미지 빌드 및 ECR 푸시(`SHA`, `dev/prod` 태그)를 수행하도록 변경했습니다.
- CD 워크플로에서 CodeDeploy 배포 생성/대기 로직으로 교체하고, `codedeploy/**` 변경 시에만 번들 업로드하도록 구성했습니다.
- `ENV_DEV` / `ENV_PROD` 멀티라인 시크릿 파싱 방식으로 환경 설정 키를 공통화했습니다.
- CodeDeploy 스크립트(`deploy_container.sh`)에서 배포 시마다 SSM Parameter Store(`analysis-core`) 값을 다시 받아 `.env`를 갱신하도록 반영했습니다.
- analysis 서비스 기준 배포 설정(`app-deploy-analysis-core`, `analysis/core/analysis-deploy.zip`, 포트 8010)을 반영했습니다.

## 📢 참고 사항
- CI/CD 관련 yml(`ci.yml`, `cd.yml`) 및 CodeDeploy 번들 파일(`appspec.yml`, `scripts/*`)을 함께 변경했습니다.
- DEV 기준 시크릿은 `ENV_DEV`에 설정되어 있어야 하며, PROD는 `ENV_PROD`로 동일 키셋을 관리하도록 구성했습니다.