### PR TITLE
[chore] dev/main push 전용으로 CI/CD 실행 조건 정리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,8 +2,7 @@ name: ai-cd
 
 on:
   push:
-    branches: [chore/v2-chatai-cicd]
-  workflow_dispatch: {}
+    branches: [dev, main]
 
 permissions:
   contents: read
@@ -97,7 +96,7 @@ jobs:
             > codedeploy/deploy.env
 
       - name: Upload bundle to S3
-        if: steps.changes.outputs.codedeploy == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changes.outputs.codedeploy == 'true'
         run: |
           set -euo pipefail
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,8 @@ on:
         required: false
         type: boolean
         default: false
-  pull_request:
-    branches: [dev, main]
   push:
-    branches: [dev, main, chore/v2-chatai-cicd]
-  workflow_dispatch: {}
+    branches: [dev, main]
 
 permissions:
   contents: read
@@ -48,7 +45,7 @@ jobs:
         run: pip-audit -l || true
 
       - name: Notify Discord (always)
-        if: always() && github.event_name != 'workflow_call'
+        if: always() && github.event_name != 'workflow_call' && secrets.DISCORD_WEBHOOK != ''
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ github.ref_name }}"


### PR DESCRIPTION
## 📝 작업 내용
- `ai-ci` 워크플로의 트리거를 `dev`, `main` 브랜치 `push` 이벤트 기준으로 정리했습니다.
- `ai-cd` 워크플로의 트리거를 `dev`, `main` 브랜치 `push` 이벤트 기준으로 변경했습니다.
- `ai-cd`의 수동 실행(`workflow_dispatch`) 트리거를 제거했습니다.
- `ci.yml` 알림 단계에서 `DISCORD_WEBHOOK`이 비어 있을 때 실패하지 않도록 가드를 추가했습니다.
- `cd.yml`의 번들 업로드 조건을 `codedeploy/**` 변경 시에만 수행하도록 정리했습니다.

## 📢 참고 사항
- 이번 변경은 워크플로 트리거/조건 정리 목적이며, 배포 스크립트 로직 자체 변경은 포함하지 않습니다.
- 머지 후 `dev` 또는 `main`에 푸시하면 CI와 CD가 자동으로 실행됩니다.
