### PR TITLE
[fix] 재사용 CI 워크플로에서 웹훅 알림 파싱 오류 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      ENV_DEV:
+        required: false
+      ENV_PROD:
+        required: false
+      DISCORD_WEBHOOK:
+        required: false
   push:
     branches: [dev, main]
 
@@ -44,9 +51,37 @@ jobs:
       - name: Dependency Audit
         run: pip-audit -l || true
 
-      - name: Notify Discord (always)
-        if: always() && github.event_name != 'workflow_call' && secrets.DISCORD_WEBHOOK != ''
+      - name: Load environment config (for notify)
+        if: github.event_name != 'workflow_call'
+        env:
+          RAW_ENV_CONFIG: ${{ github.ref_name == 'main' && secrets.ENV_PROD || secrets.ENV_DEV }}
         run: |
+          set -euo pipefail
+          if [ -z "${RAW_ENV_CONFIG:-}" ]; then
+            echo "ENV_DEV / ENV_PROD secret is empty. notify only skipped."
+            exit 0
+          fi
+
+          while IFS= read -r line; do
+            line="${line%$'\r'}"
+            [ -z "$line" ] && continue
+            case "$line" in \#*) continue ;; esac
+            key="${line%%=*}"
+            value="${line#*=}"
+            if ! [[ "$key" =~ ^[A-Z0-9_]+$ ]]; then
+              continue
+            fi
+            echo "$key=$value" >> "$GITHUB_ENV"
+          done <<< "$RAW_ENV_CONFIG"
+
+      - name: Notify Discord (always)
+        if: always() && github.event_name != 'workflow_call'
+        run: |
+          if [ -z "${DISCORD_WEBHOOK:-}" ]; then
+            echo "DISCORD_WEBHOOK not set. Skip notification."
+            exit 0
+          fi
+
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BRANCH="${{ github.ref_name }}"
           ACTOR="${{ github.actor }}"
@@ -78,7 +113,7 @@ jobs:
               ]
             }]
           }" \
-          ${{ secrets.DISCORD_WEBHOOK }}
+          "${DISCORD_WEBHOOK}"
 
   docker_publish:
     needs: verify


### PR DESCRIPTION
## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 재사용 워크플로(`workflow_call`) 환경에서 `if` 표현식의 `secrets` 참조로 발생하던 파싱 오류를 수정했습니다.
- `ci.yml` 알림 단계 로직을 변경해, `secrets.DISCORD_WEBHOOK` 직접 참조 대신 런타임에 로드된 환경변수(`DISCORD_WEBHOOK`)를 사용하도록 반영했습니다.
- `ENV_DEV` / `ENV_PROD` 값을 알림 단계에서도 로드할 수 있도록 처리했습니다.
- 웹훅 값이 비어 있을 때 알림 단계가 실패하지 않고 안전하게 스킵되도록 가드를 추가했습니다.
- `workflow_call`에서 필요한 시크릿 키 선언(`ENV_DEV`, `ENV_PROD`, `DISCORD_WEBHOOK`)을 추가했습니다.

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
- 변경 파일: `.github/workflows/ci.yml`
- 이번 수정은 CI 파싱 안정성 및 알림 실패 방지 목적이며, 배포 로직 자체 변경은 없습니다.
