### PR TITLE
[chore] 배포 이미지 태그 정책을 dev/main 기준으로 정리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,7 +77,7 @@ jobs:
           set -euo pipefail
 
           if [ "${IS_PROD}" = "true" ]; then
-            DEPLOY_TAG="prod"
+            DEPLOY_TAG="main"
           else
             DEPLOY_TAG="dev"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,24 +166,33 @@ jobs:
           set -euo pipefail
 
           if [ "${IS_PROD}" = "true" ]; then
-            TAG_ALIAS="prod"
+            TAG_ALIAS="main"
           else
             TAG_ALIAS="dev"
           fi
 
           IMAGE_URI="${ECR_REGISTRY}/${ECR_REPO}"
-          aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
-
-          docker build \
-            -t "${IMAGE_URI}:${GITHUB_SHA}" \
-            -t "${IMAGE_URI}:${TAG_ALIAS}" \
-            .
-
-          docker push "${IMAGE_URI}:${GITHUB_SHA}"
-          docker push "${IMAGE_URI}:${TAG_ALIAS}"
-
           echo "IMAGE_URI=${IMAGE_URI}" >> "$GITHUB_ENV"
           echo "TAG_ALIAS=${TAG_ALIAS}" >> "$GITHUB_ENV"
+
+      - name: Login to ECR
+        run: |
+          set -euo pipefail
+          aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push Docker image (with cache)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_URI }}:${{ github.sha }}
+            ${{ env.IMAGE_URI }}:${{ env.TAG_ALIAS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Summary
         run: |


### PR DESCRIPTION
## 📝 작업 내용
- CI에서 이미지 별칭 태그를 `prod` 대신 `main`으로 변경하여 브랜치/태그 정책을 일치시켰습니다.
- CD에서 배포 시 사용 태그를 `prod` 대신 `main`으로 변경하여 `dev -> dev`, `main -> main` 규칙으로 통일했습니다.
- 결과적으로 브랜치별 배포 태그 규칙을 아래와 같이 단순화했습니다.
  - `dev` 브랜치: `:dev` 이미지 빌드/배포
  - `main` 브랜치: `:main` 이미지 빌드/배포

## 📢 참고 사항
- 변경 파일: `.github/workflows/ci.yml`, `.github/workflows/cd.yml`
- `latest` 태그 기반 배포는 사용하지 않도록 유지했습니다.
