### PR TITLE
[fix] IPv4 기준으로 CodeDeploy Validate 헬스체크 안정화

### DIFF
--- a/codedeploy/scripts/validate_service.sh
+++ b/codedeploy/scripts/validate_service.sh
@@ -5,8 +5,9 @@ CONFIG_FILE_PRIMARY="/home/ubuntu/analysis/codedeploy-bundle/deploy.env"
 CONFIG_FILE_FALLBACK="/home/ubuntu/analysis/shared/deploy.env"
 HOST_PORT="8000"
 HEALTH_PATH="/"
+HEALTH_HOST="127.0.0.1"
 CONTAINER_NAME="analysis_ai"
-HEALTH_MAX_RETRIES="20"
+HEALTH_MAX_RETRIES="60"
 HEALTH_INTERVAL_SECONDS="3"
 
 if [ -f "$CONFIG_FILE_PRIMARY" ]; then
@@ -24,14 +25,15 @@ fi
 
 HOST_PORT="${HOST_PORT:-8000}"
 HEALTH_PATH="${HEALTH_PATH:-/}"
+HEALTH_HOST="${HEALTH_HOST:-127.0.0.1}"
 CONTAINER_NAME="${CONTAINER_NAME:-analysis_ai}"
 HEALTH_MAX_RETRIES="${HEALTH_MAX_RETRIES:-20}"
 HEALTH_INTERVAL_SECONDS="${HEALTH_INTERVAL_SECONDS:-3}"
-HEALTH_URL="http://localhost:${HOST_PORT}${HEALTH_PATH}"
+HEALTH_URL="http://${HEALTH_HOST}:${HOST_PORT}${HEALTH_PATH}"
 
 # Blue/Green green instance warm-up can take longer depending on image pull/startup.
 for ((i=1; i<=HEALTH_MAX_RETRIES; i++)); do
-  if curl -fsS --connect-timeout 2 --max-time 5 "$HEALTH_URL" | grep -Eqi "healthy|ok|up"; then
+  if curl -4 -fsS --connect-timeout 2 --max-time 5 "$HEALTH_URL" | grep -Eqi "healthy|ok|up"; then
     echo "[deploy] health check passed: $HEALTH_URL"
     exit 0
   fi


### PR DESCRIPTION
## 📝 작업 내용
- `codedeploy/scripts/validate_service.sh`의 헬스체크 대상을 `localhost` 대신 `127.0.0.1`(IPv4) 기준으로 고정했습니다.
- 초기 기동 지연을 고려해 헬스체크 재시도 횟수를 늘려(60회, 3초 간격) ValidateService 실패 가능성을 낮췄습니다.

## 📢 참고 사항
- 기존에는 `localhost` 해석 시 IPv6(`::1`)로 붙어 `connection reset`이 발생하는 경우가 있어 배포가 실패했습니다.
- 이번 수정은 동일 증상 재발 방지와 Green 인스턴스 워밍업 구간 대응을 위한 변경입니다.