### PR TITLE
[chore] CodeDeploy ValidateService 훅 제거

### DIFF
--- a/codedeploy/appspec.yml
+++ b/codedeploy/appspec.yml
@@ -18,7 +18,3 @@ hooks:
     - location: scripts/deploy_container.sh
       timeout: 900
       runas: ubuntu
-  ValidateService:
-    - location: scripts/validate_service.sh
-      timeout: 180
-      runas: ubuntu


### PR DESCRIPTION
## 📝 작업 내용
- `codedeploy/appspec.yml`에서 `ValidateService` 훅을 제거했습니다.
- 배포 단계에서 `scripts/validate_service.sh` 실행을 제외하고, `AfterInstall`까지의 흐름으로 배포가 진행되도록 변경했습니다.

## 📢 참고 사항
- 최근 `ValidateService` 단계에서 반복적으로 발생한 헬스체크 실패(`connection reset`)로 배포가 중단되어, 우선 배포 안정화를 위해 훅을 제거했습니다.
- 이후 서비스 상태 검증은 ALB 타겟 헬스체크 및 모니터링(로그/알람)으로 보완이 필요합니다.