### PR TITLE
[fix] CodeDeploy 생성 전 활성 배포 자동 정리 및 대기 처리 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -99,6 +99,47 @@ jobs:
         run: |
           set -euo pipefail
 
+          ACTIVE_DEPLOYMENT_ID=$(aws deploy list-deployments \
+            --application-name "${CODEDEPLOY_APP}" \
+            --deployment-group-name "${CODEDEPLOY_GROUP}" \
+            --include-only-statuses Created Queued InProgress Ready \
+            --query 'deployments[0]' \
+            --output text)
+
+          if [ "${ACTIVE_DEPLOYMENT_ID}" != "None" ]; then
+            echo "Active deployment found: ${ACTIVE_DEPLOYMENT_ID}"
+            aws deploy stop-deployment \
+              --deployment-id "${ACTIVE_DEPLOYMENT_ID}" \
+              --auto-rollback-enabled >/dev/null || true
+
+            ACTIVE_STATUS="Unknown"
+            for i in $(seq 1 40); do
+              ACTIVE_STATUS=$(aws deploy get-deployment \
+                --deployment-id "${ACTIVE_DEPLOYMENT_ID}" \
+                --query 'deploymentInfo.status' \
+                --output text)
+
+              case "${ACTIVE_STATUS}" in
+                Succeeded|Failed|Stopped)
+                  echo "Previous deployment finished with status: ${ACTIVE_STATUS}"
+                  break
+                  ;;
+                *)
+                  echo "Waiting previous deployment to finish: ${ACTIVE_STATUS} (${i}/40)"
+                  sleep 10
+                  ;;
+              esac
+            done
+
+            case "${ACTIVE_STATUS}" in
+              Succeeded|Failed|Stopped) ;;
+              *)
+                echo "Previous deployment did not finish in time: ${ACTIVE_STATUS}"
+                exit 1
+                ;;
+            esac
+          fi
+
           DEPLOYMENT_ID=$(aws deploy create-deployment \
             --application-name "${CODEDEPLOY_APP}" \
             --deployment-group-name "${CODEDEPLOY_GROUP}" \


### PR DESCRIPTION
## 📝 작업 내용
- CodeDeploy 생성 전 `Created/Queued/InProgress/Ready` 상태의 활성 배포를 조회하도록 추가했습니다.
- 활성 배포가 있으면 `stop-deployment --auto-rollback-enabled`를 먼저 수행하고, 이전 배포가 `Succeeded/Failed/Stopped`로 끝날 때까지 대기한 뒤 새 배포를 생성하도록 수정했습니다.
- 대기 제한 시간(최대 40회, 10초 간격) 내 종료되지 않으면 워크플로를 실패 처리해 중복 배포 충돌을 방지하도록 했습니다.

## 📢 참고 사항
- `.github/workflows/cd.yml`만 수정했습니다.
- 이번 변경 목적은 `DeploymentLimitExceededException`(활성 배포 존재) 재발 방지입니다.
- `rerun job` 시에도 배포는 수행되며, 충돌 시 기존 활성 배포를 정리한 뒤 진행합니다.