### PR TITLE
[refactor]#25 문제 추천 로직 보완 및 정적 문제 추천 사유 생성

### DIFF
--- a/app/domain/recommend/recommend_llm_service.py
+++ b/app/domain/recommend/recommend_llm_service.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 from typing import Any
 
@@ -35,6 +34,7 @@ class RecommendLlmService:
         similar_user_count = recommendation_context.get("similar_user_count", 0)
         collaborative_basis = recommendation_context.get("collaborative_basis", "")
         starter_basis = recommendation_context.get("starter_basis", "")
+        focus_tags = weak_tags or matched_tags or tags[:2]
 
         # TODO : 프롬프트 엔지니어링 고도화 필요
         system_prompt = (
@@ -49,6 +49,7 @@ class RecommendLlmService:
         - 시나리오: {scenario}
         - 사용자 레벨: {user_level}
         - 취약 태그: {weak_tags}
+        - 현재 보완 포인트 : {focus_tags}
         
         [추천 문제 정보]
         - 제목: {title}
@@ -163,22 +164,14 @@ class RecommendLlmService:
     def _fallback_reason(self, *, scenario:str, weak_tags: list[str], recommendation_context: dict[str, Any],) -> str:
         recommendation_type = recommendation_context.get("recommendation_type", "")
         matched_tags = recommendation_context.get("matched_tags", [])
+        focus_tags = weak_tags or matched_tags
+        focus = ", ".join(focus_tags[::2]) if focus_tags else "핵심 개념"
 
         if recommendation_type == "collaborative":
-            if matched_tags:
-                return (
-                    f"비슷한 풀이 패턴을 보인 사용자들이 해결한 문제 중 "
-                    f"{', '.join(matched_tags[:2])} 보완에 도움이 될 문제예요."
-                )
-            if weak_tags:
-                return (
-                    f"유사한 어려움을 겪은 사용자들의 풀이 흐름을 바탕으로 "
-                    f"{', '.join(weak_tags[:2])} 보완에 맞춰 추천한 문제예요."
-                )
-            return "비슷한 풀이 패턴을 보인 사용자들의 학습 흐름을 바탕으로 추천한 문제예요."
+            return f"유사한 풀이 패턴에서 자주 막히는 {focus} 보완에 도움이 되는 문제예요."
 
         if scenario == "NEW":
-            return "초기 학습 흐름을 잡고 핵심 개념을 점검하기 좋도록 추천한 문제예요."
-        return "사용자의 취약 태그와 유사한 학습 패턴을 바탕으로 추천한 문제예요."
+            return f"초기 학습 흐름을 잡고 {focus}을 안정적으로 점검하기 좋은 문제예요."
+        return f"현재 학습 단계에서 {focus}을 보완하며 풀이 흐름을 정리하기 좋은 문제예요."
 
 recommend_llm_service = RecommendLlmService()

--- a/app/domain/recommend/recommend_router.py
+++ b/app/domain/recommend/recommend_router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from app.common.api_response import CommonResponse
 from app.common.exceptions.custom_exception import (
@@ -16,42 +16,108 @@ from app.domain.recommend.recommendation_schemas import (
 
 router = APIRouter()
 
+def _merge_to_five(base_ids: list[str], static_ids: list[str], desired_count:int=5,)-> list[str]:
+    merged = []
+    seen = set()
+
+    for pid in base_ids + static_ids:
+        if pid in seen:
+            continue
+        seen.add(pid)
+        merged.append(pid)
+        if len(merged) >= desired_count:
+            break
+
+    return merged
 
 @router.post("", response_model=CommonResponse[RecommendResponseData])
 async def get_recommendations(request: RecommendRequest):
     solved_ids = request.filter_info.solved_problem_ids
     challenge_ids = request.filter_info.challenge_problem_ids
 
+    recommendation_items: list[dict] = []
 
     if request.scenario == "NEW":
         if len(solved_ids) >= 5:
             raise InvalidStarterConditionException()
 
-        recommend_result = await recommend_service.get_static_recomendations(
+        static_result = await recommend_service.get_static_recomendations(
             user_level=request.user_level,
             solved_problem_ids=solved_ids,
             challenge_problem_ids=challenge_ids,
+            limit=5,
         )
+
+        if "recommended_problem_ids" not in static_result:
+            raise RecommendationNotFoundException(
+                static_result.get("message", "추천 결과가 없습니다.")
+            )
+
+
+        for pid in static_result["recommended_problem_ids"]:
+            recommendation_items.append(
+                {
+                    "problem_id": int(pid),
+                    "weak_tags": static_result.get("weak_tags",[]),
+                    "reason_context": static_result.get("reason_context", {}),
+                }
+            )
     else:
         current_prob = challenge_ids[-1] if challenge_ids else 0
-        recommend_result = await recommend_service.get_collaborative_recommendations(
-                user_id=request.user_id,
-                current_problem_id=current_prob,
-                exclude_ids=solved_ids,
+        collab_result = await recommend_service.get_collaborative_recommendations(
+            user_id=request.user_id,
+            current_problem_id=current_prob,
+            exclude_ids=solved_ids,
+            limit=5,
         )
 
-    if "recommended_problem_ids" not in recommend_result:
-        raise RecommendationNotFoundException(
-            recommend_result.get("message", "추천 결과가 없습니다.")
-        )
+        collab_ids = collab_result.get("recommended_problem_ids",[])
+        collab_context = collab_result.get("reason_context", {})
+        collab_weak_tags = collab_result.get("weak_tags", [])
 
-    weak_tags = recommend_result.get("weak_tags", [])
-    reason_context = recommend_result.get("reason_context", {})
-    recommendations = []
+        if len(collab_ids) < 5:
+            extra_excluded = [int(x) for x in collab_ids]
+            static_fill_result = await recommend_service.get_static_recomendations(
+                user_level=request.user_level,
+                solved_problem_ids=solved_ids + extra_excluded,
+                challenge_problem_ids=challenge_ids + extra_excluded,
+                limit=10,
+            )
+            static_fill_ids = static_fill_result.get("recommended_problem_ids", [])
+        else:
+            static_fill_result = {}
+            static_fill_ids = []
 
+        merged_ids = _merge_to_five(collab_ids, static_fill_ids, desired_count=5)
 
-    for p_id in recommend_result["recommended_problem_ids"]:
-        problem_id = int(p_id)
+        if not merged_ids:
+            raise RecommendationNotFoundException(
+                collab_result.get("message", "추천 결과가 없습니다.")
+            )
+
+        collab_id_set = set(collab_ids)
+        for pid in merged_ids:
+            if pid in collab_id_set:
+                recommendation_items.append(
+                    {
+                        "problem_id": int(pid),
+                        "weak_tags": collab_weak_tags,
+                        "reason_context": collab_context,
+                    }
+                )
+            else:
+                recommendation_items.append(
+                    {
+                        "problem_id": int(pid),
+                        "weak_tags": static_fill_result.get("weak_tags", []),
+                        "reason_context": static_fill_result.get("reason_context", {}),
+                    }
+                )
+
+    recommendations =  []
+
+    for item in recommendation_items:
+        problem_id = item["problem_id"]
         problem_payload = await vector_db.get_problem_by_id(problem_id)
 
         print(f"[DEBUG] problem_id={problem_id}")
@@ -60,9 +126,9 @@ async def get_recommendations(request: RecommendRequest):
         reason_msg = await recommend_llm_service.generate_reason(
             scenario=request.scenario,
             user_level=request.user_level,
-            weak_tags=weak_tags,
+            weak_tags=item["weak_tags"],
             problem_payload=problem_payload,
-            recommendation_context=reason_context,
+            recommendation_context=item["reason_context"],
         )
 
         recommendations.append(
@@ -72,9 +138,13 @@ async def get_recommendations(request: RecommendRequest):
             )
         )
 
+    if not recommendations:
+        raise RecommendationNotFoundException("추천 결과가 없습니다.")
+
     response_data = RecommendResponseData(
         user_id=request.user_id,
         scenario=request.scenario,
         recommendations=recommendations,
     )
+
     return CommonResponse.success_response(message="OK", data=response_data)

--- a/app/domain/recommend/recommend_service.py
+++ b/app/domain/recommend/recommend_service.py
@@ -1,6 +1,4 @@
 # 문제 추천 수식
-
-
 from app.database.vector_db import vector_db
 
 
@@ -16,11 +14,11 @@ class RecommendService:
         challenge_problem_ids: list[int],
         limit: int = 5,
     ):
-        # 문제 id 수정 => 최대 10개 정도 추려서 넣어놓기 (초기 사용자가 안 풀 것 같은 문제로)
+
         static_pool_by_level = {
-            "newbie": [1, 2, 3, 4, 5, 6, 7, 8],
-            "pupil": [1, 2, 3, 4, 5, 6, 7, 8],
-            "specialist": [1, 2, 3, 4, 5, 6, 7, 8],
+            "newbie": [1, 22, 23, 24, 25, 26, 40],
+            "pupil": [27, 28, 29, 30, 31, 11, 32],
+            "specialist": [8, 33, 34, 35, 36, 37, 38, 39],
         }
 
         # 유저 레벨이 알 수 없는 값이라면 newbie로 지정
@@ -43,14 +41,15 @@ class RecommendService:
         }
 
     async def get_collaborative_recommendations(
-        self, user_id: int, current_problem_id: int, exclude_ids: list[int] = None
+        self, user_id: int, current_problem_id: int, exclude_ids: list[int] = None, limit: int =5,
     ):
         # 1. 현재 사용자의 가장 최신 기억 가져오기
         user_memories, _ = self.vector_db.client.scroll(
             collection_name="User_memories",
             scroll_filter={"must": [{"key": "user_id", "match": {"value": user_id}}]},
-            limit=1,
+            limit=100,
             with_vectors=True,
+            with_payload=True,
         )
 
         if not user_memories:
@@ -59,6 +58,7 @@ class RecommendService:
 
         target_memory = user_memories[0]
         target_vector = target_memory.vector
+        target_payload = target_memory.payload or {}
         target_weak_tags = set(target_memory.payload.get("weak_tags", []))
 
         # 제외할 문제 목록 = 이미 푼 문제 + 현재 도전 중인 문제
@@ -74,7 +74,7 @@ class RecommendService:
             query_filter={
                 "must_not": [{"key": "user_id", "match": {"value": user_id}}]
             },
-            limit=5,
+            limit=30,
             with_payload=True,
         ).points
 
@@ -117,21 +117,24 @@ class RecommendService:
         sorted_recommendations = sorted(
             candidate_scores.items(), key=lambda x: x[1], reverse=True
         )
-        top_3_ids = [str(p_id) for p_id, score in sorted_recommendations[:3]]
+        top_ids = [str(p_id) for p_id, score in sorted_recommendations[:limit]]
 
-        top_problem_id = int(top_3_ids[0])
-        top_matched_tags = list(candidate_tag_matches.get(top_problem_id, set()))
+        all_matched_tags = set()
+        for pid in top_ids:
+            all_matched_tags.update(candidate_tag_matches.get(int(pid), set()))
+        # top_problem_id = int(top_ids[0])
+        # top_matched_tags = list(candidate_tag_matches.get(top_problem_id, set()))
 
-        print(f"🎯 [DEBUG] 최종 추천 후보 리스트: {top_3_ids}")
+        print(f"🎯 [DEBUG] 최종 추천 후보 리스트: {top_ids}")
 
         return {
             "user_id": user_id,
-            "recommended_problem_ids": top_3_ids,
+            "recommended_problem_ids": top_ids,
             "weak_tags": list(target_weak_tags),
             "reason_context": {
                 "recommendation_type": "collaborative",
                 "similar_user_count": len(similar_users),
-                "matched_tags": top_matched_tags,
+                "matched_tags": list(all_matched_tags),
                 "collaborative_basis": "비슷한 취약 태그와 풀이 패턴을 보인 사용자들이 해결한 문제를 기반으로 추천",
             },
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #25 
- closed #25 
- #23 

## 📝 작업 내용
- recommend_service.py 
    - 정적 추천 문제를 레벨별로 정리하고 기본 추천 개수를 5개 기준으로 유지하도록 보완 
    - 협업 추천 결과 개수 (limit)를 5개 기준으로 동작하도록 정리
- recommend_router.py 
    - DAILY/ON_DEMAND 에서 협업 추천 결과가 부족할 떄 정적 추천으로 보충하여 최대 5문제를 반환하도록 로직 추가 
    - 중복 문제는 제거 후 최종 추천 개수 맞추도록 함 
- recommend_llm_service.py 
    - 추천 사유 생성 프롬프트/후처리 로직 정리
    - 정적 문제 또한 llm 추천 사유 생성할 수 있도록 수정

## 📸 스크린샷 (선택)
<img width="715" height="656" alt="Screenshot 2026-03-06 at 4 40 16 PM" src="https://github.com/user-attachments/assets/4885b830-f612-4820-9759-ed32c919b981" />
<img width="715" height="656" alt="Screenshot 2026-03-06 at 4 40 37 PM" src="https://github.com/user-attachments/assets/6936624b-b530-4894-a16a-8789aecd0bf6" />

## 📢 참고 사항

