### PR TITLE
[fix] dev/main 푸시 시 ENV_DEV로 배포

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,14 +17,17 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       publish_image: true
-    secrets: inherit
+    secrets:
+      ENV_DEV: ${{ secrets.ENV_DEV }}
+      ENV_PROD: ${{ secrets.ENV_DEV }}
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
   deploy:
     needs: ci
     runs-on: ubuntu-latest
     env:
       IS_PROD: ${{ github.ref_name == 'main' }}
-      RAW_ENV_CONFIG: ${{ github.ref_name == 'main' && secrets.ENV_PROD || secrets.ENV_DEV }}
+      RAW_ENV_CONFIG: ${{ secrets.ENV_DEV }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 📝 작업 내용
- `.github/workflows/cd.yml`에서 `dev`, `main` 브랜치 push 모두 CD가 실행되도록 유지했습니다.
- CD에서 재사용하는 CI(`ci.yml`) 호출 시 `ENV_DEV`, `ENV_PROD`를 모두 `secrets.ENV_DEV`로 전달하도록 변경했습니다.
- `deploy` 잡의 `RAW_ENV_CONFIG`를 `secrets.ENV_DEV`로 고정해, 브랜치와 무관하게 dev 환경값으로 배포되도록 맞췄습니다.
- 결과적으로 `dev`/`main` 어디서 push해도 메인 서버 배포 파이프라인을 동일한(dev) 환경설정으로 수행합니다.