### PR TITLE
[fix] monitoring 배포를 CodeDeploy에서 SSM으로 전환

### DIFF
--- a/.github/workflows/cd-monitoring.yml
+++ b/.github/workflows/cd-monitoring.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Validate required vars
         run: |
           set -euo pipefail
-          for k in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION DEPLOY_BUCKET MONITORING_DEPLOY_KEY MONITORING_CODEDEPLOY_APP MONITORING_CODEDEPLOY_GROUP; do
+          for k in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION DEPLOY_BUCKET MONITORING_DEPLOY_KEY; do
             if [ -z "${!k:-}" ]; then
               echo "Missing required var: $k"
               exit 1
@@ -67,6 +67,7 @@ jobs:
             "AWS_REGION=${AWS_REGION}" \
             "MONITORING_EC2_TAG_KEY=${MONITORING_EC2_TAG_KEY:-MonitoringTarget}" \
             "MONITORING_EC2_TAG_VALUE=${MONITORING_EC2_TAG_VALUE:-analysis}" \
+            "MONITORING_DEPLOY_DIR=${MONITORING_DEPLOY_DIR:-/home/ubuntu/monitoring}" \
             "GRAFANA_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}" \
             "GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}" \
             > monitoring/deploy.env
@@ -78,20 +79,56 @@ jobs:
           zip -r /tmp/monitoring-deploy.zip .
           aws s3 cp /tmp/monitoring-deploy.zip "s3://${DEPLOY_BUCKET}/${MONITORING_DEPLOY_KEY}"
 
-      - name: Create CodeDeploy deployment
+      - name: Resolve monitoring instance
         run: |
           set -euo pipefail
-          DEPLOYMENT_ID=$(aws deploy create-deployment \
-            --application-name "${MONITORING_CODEDEPLOY_APP}" \
-            --deployment-group-name "${MONITORING_CODEDEPLOY_GROUP}" \
-            --revision "revisionType=S3,s3Location={bucket=${DEPLOY_BUCKET},key=${MONITORING_DEPLOY_KEY},bundleType=zip}" \
-            --query 'deploymentId' \
+          MONITORING_EC2_TAG_KEY="${MONITORING_EC2_TAG_KEY:-MonitoringTarget}"
+          MONITORING_EC2_TAG_VALUE="${MONITORING_EC2_TAG_VALUE:-analysis}"
+
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:${MONITORING_EC2_TAG_KEY},Values=${MONITORING_EC2_TAG_VALUE}" \
+              "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].InstanceId | [0]" \
             --output text)
 
-          echo "DEPLOYMENT_ID=${DEPLOYMENT_ID}" >> "$GITHUB_ENV"
-          echo "Created monitoring deployment: ${DEPLOYMENT_ID}"
+          if [ -z "${INSTANCE_ID}" ] || [ "${INSTANCE_ID}" = "None" ]; then
+            echo "No running monitoring instance found for tag ${MONITORING_EC2_TAG_KEY}=${MONITORING_EC2_TAG_VALUE}"
+            exit 1
+          fi
 
-      - name: Wait deployment result
+          echo "MONITORING_INSTANCE_ID=${INSTANCE_ID}" >> "$GITHUB_ENV"
+          echo "Target monitoring instance: ${INSTANCE_ID}"
+
+      - name: Deploy monitoring via SSM
         run: |
           set -euo pipefail
-          aws deploy wait deployment-successful --deployment-id "${DEPLOYMENT_ID}"
+          MONITORING_DEPLOY_DIR="${MONITORING_DEPLOY_DIR:-/home/ubuntu/monitoring}"
+          REMOTE_ROOT="${MONITORING_DEPLOY_DIR}/current"
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "${MONITORING_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Deploy monitoring stack from ${DEPLOY_BUCKET}/${MONITORING_DEPLOY_KEY}" \
+            --parameters commands="set -euo pipefail, \
+              mkdir -p ${MONITORING_DEPLOY_DIR}, \
+              aws s3 cp s3://${DEPLOY_BUCKET}/${MONITORING_DEPLOY_KEY} /tmp/monitoring-deploy.zip, \
+              rm -rf ${REMOTE_ROOT}, \
+              mkdir -p ${REMOTE_ROOT}, \
+              unzip -o /tmp/monitoring-deploy.zip -d ${REMOTE_ROOT}, \
+              cd ${REMOTE_ROOT}, \
+              if docker compose version >/dev/null 2>&1; then docker compose up -d --remove-orphans; else docker-compose up -d --remove-orphans; fi" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM command: ${COMMAND_ID}"
+
+          aws ssm wait command-executed \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${MONITORING_INSTANCE_ID}"
+
+          aws ssm get-command-invocation \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${MONITORING_INSTANCE_ID}" \
+            --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
+            --output json


### PR DESCRIPTION
## 📝 작업 내용
- `cd-monitoring.yml`에서 CodeDeploy 단계(`create-deployment`, `wait deployment`)를 제거하고 SSM 배포로 변경했습니다.
- 모니터링 대상 인스턴스를 `MONITORING_EC2_TAG_KEY/VALUE` 태그로 조회하도록 추가했습니다.
- S3에 업로드한 `monitoring-deploy.zip`을 대상 인스턴스에서 다운로드/압축해제 후 `docker compose up -d --remove-orphans` 실행하도록 변경했습니다.
- 더 이상 사용하지 않는 CodeDeploy 관련 필수 변수(`MONITORING_CODEDEPLOY_APP`, `MONITORING_CODEDEPLOY_GROUP`) 검증을 제거했습니다.
- 배포 결과 확인을 위해 SSM command 완료 대기 및 invocation 결과 출력 단계를 추가했습니다.

## 📢 참고 사항
- 단일 모니터링 EC2 구조에 맞춘 배포 방식으로 정리한 변경입니다.
- `ENV_DEV/ENV_PROD`에 `MONITORING_EC2_TAG_KEY`, `MONITORING_EC2_TAG_VALUE`, `MONITORING_DEPLOY_DIR`가 있으면 우선 사용하고, 없으면 기본값을 사용합니다.
- 대상 인스턴스는 SSM Managed Instance 상태여야 하며, 인스턴스 IAM Role에 S3 읽기 권한이 필요합니다.