### PR TITLE
[fix] SSM 파라미터를 JSON 파일 방식으로 전달하도록 수정 (quoting 오류 해결)

### DIFF
--- a/.github/workflows/cd-monitoring.yml
+++ b/.github/workflows/cd-monitoring.yml
@@ -105,19 +105,15 @@ jobs:
           set -euo pipefail
           MONITORING_DEPLOY_DIR="${MONITORING_DEPLOY_DIR:-/opt/monitoring/monitoring-server}"
           REMOTE_ROOT="${MONITORING_DEPLOY_DIR}/current"
+          cat > /tmp/ssm-params.json <<EOF
+          {"commands":["bash -lc \"set -euo pipefail; mkdir -p ${MONITORING_DEPLOY_DIR}; aws s3 cp s3://${DEPLOY_BUCKET}/${MONITORING_DEPLOY_KEY} /tmp/monitoring-deploy.zip; rm -rf ${REMOTE_ROOT}; mkdir -p ${REMOTE_ROOT}; unzip -o /tmp/monitoring-deploy.zip -d ${REMOTE_ROOT}; cd ${REMOTE_ROOT}; if docker compose version >/dev/null 2>&1; then docker compose up -d --remove-orphans; else docker-compose up -d --remove-orphans; fi\""]}
+          EOF
 
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "${MONITORING_INSTANCE_ID}" \
             --document-name "AWS-RunShellScript" \
             --comment "Deploy monitoring stack from ${DEPLOY_BUCKET}/${MONITORING_DEPLOY_KEY}" \
-            --parameters commands="bash -lc 'set -euo pipefail; \
-              mkdir -p ${MONITORING_DEPLOY_DIR}; \
-              aws s3 cp s3://${DEPLOY_BUCKET}/${MONITORING_DEPLOY_KEY} /tmp/monitoring-deploy.zip; \
-              rm -rf ${REMOTE_ROOT}; \
-              mkdir -p ${REMOTE_ROOT}; \
-              unzip -o /tmp/monitoring-deploy.zip -d ${REMOTE_ROOT}; \
-              cd ${REMOTE_ROOT}; \
-              if docker compose version >/dev/null 2>&1; then docker compose up -d --remove-orphans; else docker-compose up -d --remove-orphans; fi'" \
+            --parameters file:///tmp/ssm-params.json \
             --query "Command.CommandId" \
             --output text)
 


### PR DESCRIPTION
## 📝 작업 내용
- `aws ssm send-command` 호출 시 `--parameters`를 인라인 문자열(`commands="..."`)로 전달하던 방식을 JSON 파일(`file:///tmp/ssm-params.json`) 전달 방식으로 변경했습니다.
- 따옴표/이스케이프 파싱 오류(`Expected: ',', received: '''`)가 발생하지 않도록 SSM 명령 파라미터 전달 방식을 안정화했습니다.
- 기존 배포 명령 로직(모니터링 zip 다운로드 → 압축 해제 → `docker compose up -d --remove-orphans`)은 유지한 채 파라미터 전달부만 수정했습니다.

## 📢 참고 사항
- 변경 파일: `.github/workflows/cd-monitoring.yml`
- 목적: monitoring-cd 실행 중 SSM 파라미터 파싱 에러로 잡이 실패하는 문제 해결 (`exit code 252`)