### PR TITLE
[fix] dev/main 배포 흐름 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,15 +19,138 @@ jobs:
       publish_image: true
     secrets:
       ENV_DEV: ${{ secrets.ENV_DEV }}
-      ENV_PROD: ${{ secrets.ENV_DEV }}
+      ENV_PROD: ${{ secrets.ENV_PROD }}
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
-  deploy:
+  deploy_dev:
+    if: github.ref_name == 'dev'
     needs: ci
     runs-on: ubuntu-latest
     env:
-      IS_PROD: ${{ github.ref_name == 'main' }}
       RAW_ENV_CONFIG: ${{ secrets.ENV_DEV }}
+      INSTANCE_ID: ${{ secrets.AI_INSTANCE_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load environment config
+        run: |
+          set -euo pipefail
+          if [ -z "${RAW_ENV_CONFIG:-}" ]; then
+            echo "ENV_DEV secret is empty"
+            exit 1
+          fi
+
+          while IFS= read -r line; do
+            line="${line%$'\r'}"
+            [ -z "$line" ] && continue
+            case "$line" in \#*) continue ;; esac
+
+            key="${line%%=*}"
+            value="${line#*=}"
+
+            if ! [[ "$key" =~ ^[A-Z0-9_]+$ ]]; then
+              echo "Invalid key in ENV config: $key"
+              exit 1
+            fi
+
+            echo "$key=$value" >> "$GITHUB_ENV"
+          done <<< "$RAW_ENV_CONFIG"
+
+      - name: Validate required vars
+        run: |
+          set -euo pipefail
+          for k in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION ECR_REGISTRY ECR_REPO DISCORD_WEBHOOK INSTANCE_ID; do
+            if [ -z "${!k:-}" ]; then
+              echo "Missing required var: $k"
+              exit 1
+            fi
+          done
+
+      - name: Deploy to dev instance via SSM
+        run: |
+          set -euo pipefail
+
+          CONTAINER_NAME="${CONTAINER_NAME:-analysis_api_server}"
+          HOST_PORT="${HOST_PORT:-8010}"
+          APP_PORT="${APP_PORT:-8000}"
+          HEALTH_PATH="${HEALTH_PATH:-/}"
+          SSM_PARAM_NAME="${SSM_PARAM_NAME:-analysis-core-dev}"
+          APP_ENV_PATH="${APP_ENV_PATH:-/home/ubuntu/app/.env}"
+          APP_ENV_DIR=$(dirname "${APP_ENV_PATH}")
+
+          cat > /tmp/ssm-params.json <<EOF
+          {"commands":["bash -lc \"set -euo pipefail; mkdir -p ${APP_ENV_DIR}; aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}; docker pull ${ECR_REGISTRY}/${ECR_REPO}:dev; aws ssm get-parameter --name ${SSM_PARAM_NAME} --with-decryption --query Parameter.Value --output text --region ${AWS_REGION} > ${APP_ENV_PATH}; docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true; docker run -d --name ${CONTAINER_NAME} --restart unless-stopped -p ${HOST_PORT}:${APP_PORT} --env-file ${APP_ENV_PATH} ${ECR_REGISTRY}/${ECR_REPO}:dev; sleep 5; curl -fsS http://localhost:${HOST_PORT}${HEALTH_PATH} >/dev/null; docker image prune -f >/dev/null 2>&1 || true\""]}
+          EOF
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "${INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Deploy dev image ${ECR_REGISTRY}/${ECR_REPO}:dev" \
+            --parameters file:///tmp/ssm-params.json \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "COMMAND_ID=${COMMAND_ID}" >> "$GITHUB_ENV"
+          echo "Started SSM command: ${COMMAND_ID}"
+
+          aws ssm wait command-executed \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${INSTANCE_ID}"
+
+          aws ssm get-command-invocation \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${INSTANCE_ID}" \
+            --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
+            --output json
+
+      - name: Notify Discord (always)
+        if: always()
+        run: |
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BRANCH="${{ github.ref_name }}"
+          ACTOR="${{ github.actor }}"
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+
+          if [ -z "$COMMIT_MSG" ]; then
+            COMMIT_MSG="(커밋 메시지를 이벤트에서 가져올 수 없음)"
+          fi
+
+          COMMIT_MSG_ESCAPED=$(printf '%s' "$COMMIT_MSG" | sed 's/\\/\\\\/g; s/\"/\\\"/g; :a;N;$!ba;s/\n/\\n/g')
+
+          if [ "${{ job.status }}" = "success" ]; then
+            STATUS="✅ 성공"
+            COLOR="65280"
+          else
+            STATUS="❌ 실패"
+            COLOR="16711680"
+          fi
+
+          COMMAND_ID_MSG="${COMMAND_ID:-N/A}"
+
+          curl -X POST -H "Content-Type: application/json" \
+          -d "{
+            \"embeds\": [{
+              \"title\": \"[AI - analysis] Dev CD 배포 결과 알림\",
+              \"description\": \"**상태**: ${STATUS}\\n**브랜치**: ${BRANCH}\\n**담당자**: ${ACTOR}\",
+              \"color\": ${COLOR},
+              \"fields\": [
+                {\"name\": \"커밋 메시지\", \"value\": \"${COMMIT_MSG_ESCAPED}\"},
+                {\"name\": \"SSM Command ID\", \"value\": \"${COMMAND_ID_MSG}\"},
+                {\"name\": \"배포 로그\", \"value\": \"${RUN_URL}\"}
+              ]
+            }]
+          }" \
+          "${DISCORD_WEBHOOK}"
+
+  deploy_main:
+    if: github.ref_name == 'main'
+    needs: ci
+    runs-on: ubuntu-latest
+    env:
+      IS_PROD: true
+      RAW_ENV_CONFIG: ${{ secrets.ENV_PROD }}
 
     steps:
       - name: Checkout
@@ -71,23 +194,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${IS_PROD}" = "true" ]; then
-            DEPLOY_TAG="main"
-          else
-            DEPLOY_TAG="dev"
-          fi
-
           mkdir -p codedeploy
           printf "%s\n" \
             "AWS_REGION=${AWS_REGION}" \
             "ECR_REGISTRY=${ECR_REGISTRY}" \
             "ECR_REPO=${ECR_REPO}" \
-            "DEPLOY_TAG=${DEPLOY_TAG}" \
+            "DEPLOY_TAG=main" \
             "CONTAINER_NAME=analysis_api_server" \
             "HOST_PORT=8010" \
             "APP_PORT=8000" \
             "HEALTH_PATH=/" \
-            "SSM_PARAM_NAME=analysis-core" \
+            "SSM_PARAM_NAME=${SSM_PARAM_NAME:-analysis-core}" \
             > codedeploy/deploy.env
 
       - name: Upload bundle to S3


### PR DESCRIPTION
## 📝 작업 내용
- `cd.yml`에서 배포 job을 `dev`와 `main` 기준으로 분리했습니다.
- `dev` 브랜치 배포는 단일 EC2 인스턴스에 SSM으로 직접 접속해 Docker 컨테이너를 재기동하도록 변경했습니다.
- `main` 브랜치 배포는 기존 CodeDeploy + ASG + ALB 방식이 유지되도록 분리했습니다.
- 재사용 워크플로우 호출 시 `ENV_DEV`, `ENV_PROD`가 브랜치 목적에 맞게 전달되도록 수정했습니다.
- `dev` 배포 시 `AI_INSTANCE_ID`를 사용해 지정된 인스턴스에만 배포되도록 구성했습니다.