### PR TITLE
[fix] dev 배포 환경을 ENV_DEV 기반으로 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,12 +76,14 @@ jobs:
           HOST_PORT="${HOST_PORT:-8010}"
           APP_PORT="${APP_PORT:-8000}"
           HEALTH_PATH="${HEALTH_PATH:-/}"
-          SSM_PARAM_NAME="${SSM_PARAM_NAME:-analysis-core-dev}"
           APP_ENV_PATH="${APP_ENV_PATH:-/home/ubuntu/app/.env}"
           APP_ENV_DIR=$(dirname "${APP_ENV_PATH}")
+          APP_ENV_CONTENT_BASE64=$(printf '%s\n' "$RAW_ENV_CONFIG" | \
+            grep -Ev '^(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_REGION|ECR_REGISTRY|ECR_REPO|CODEDEPLOY_APP|CODEDEPLOY_GROUP|DEPLOY_BUCKET|DEPLOY_KEY|DISCORD_WEBHOOK|CONTAINER_NAME|HOST_PORT|APP_PORT|HEALTH_PATH|SSM_PARAM_NAME|APP_ENV_PATH)=' | \
+            base64 -w0)
 
           cat > /tmp/ssm-params.json <<EOF
-          {"commands":["bash -lc \"set -euo pipefail; mkdir -p ${APP_ENV_DIR}; aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}; docker pull ${ECR_REGISTRY}/${ECR_REPO}:dev; aws ssm get-parameter --name ${SSM_PARAM_NAME} --with-decryption --query Parameter.Value --output text --region ${AWS_REGION} > ${APP_ENV_PATH}; docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true; docker run -d --name ${CONTAINER_NAME} --restart unless-stopped -p ${HOST_PORT}:${APP_PORT} --env-file ${APP_ENV_PATH} ${ECR_REGISTRY}/${ECR_REPO}:dev; sleep 5; curl -fsS http://localhost:${HOST_PORT}${HEALTH_PATH} >/dev/null; docker image prune -f >/dev/null 2>&1 || true\""]}
+          {"commands":["bash -lc \"set -euo pipefail; mkdir -p ${APP_ENV_DIR}; printf '%s' '${APP_ENV_CONTENT_BASE64}' | base64 -d > ${APP_ENV_PATH}; aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}; docker pull ${ECR_REGISTRY}/${ECR_REPO}:dev; docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true; docker run -d --name ${CONTAINER_NAME} --restart unless-stopped -p ${HOST_PORT}:${APP_PORT} --env-file ${APP_ENV_PATH} ${ECR_REGISTRY}/${ECR_REPO}:dev; sleep 5; curl -fsS http://localhost:${HOST_PORT}${HEALTH_PATH} >/dev/null; docker image prune -f >/dev/null 2>&1 || true\""]}
           EOF
 
           COMMAND_ID=$(aws ssm send-command \


### PR DESCRIPTION
## 📝 작업 내용
- `dev` 배포가 운영용 Parameter Store를 참조하지 않도록 수정했습니다.
- `dev` 브랜치 배포 시 GitHub Secret `ENV_DEV` 내용을 직접 `.env`로 생성해 단일 EC2에 배포하도록 변경했습니다.
- `main` 브랜치 배포는 기존 CodeDeploy + ASG + ALB + Parameter Store 구조를 그대로 유지하도록 분리했습니다.
- `dev` 배포는 `AI_INSTANCE_ID`를 사용해 지정된 단일 인스턴스에만 SSM으로 배포되도록 구성했습니다.