### PR TITLE
[fix] dev SSM 배포 대기 로직 개선 및 로그 출력 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -97,15 +97,50 @@ jobs:
           echo "COMMAND_ID=${COMMAND_ID}" >> "$GITHUB_ENV"
           echo "Started SSM command: ${COMMAND_ID}"
 
-          aws ssm wait command-executed \
-            --command-id "${COMMAND_ID}" \
-            --instance-id "${INSTANCE_ID}"
+          FINAL_STATUS=""
+          for i in $(seq 1 120); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${INSTANCE_ID}" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Unknown")
+
+            echo "SSM command status: ${STATUS} (${i}/120)"
+
+            case "${STATUS}" in
+              Success)
+                FINAL_STATUS="${STATUS}"
+                break
+                ;;
+              Failed|Cancelled|TimedOut|Cancelling)
+                FINAL_STATUS="${STATUS}"
+                break
+                ;;
+              Pending|InProgress|Delayed|Unknown)
+                sleep 30
+                ;;
+              *)
+                FINAL_STATUS="${STATUS}"
+                break
+                ;;
+            esac
+          done
 
           aws ssm get-command-invocation \
             --command-id "${COMMAND_ID}" \
             --instance-id "${INSTANCE_ID}" \
             --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
             --output json
+
+          if [ -z "${FINAL_STATUS}" ]; then
+            echo "SSM command did not finish within the allotted time"
+            exit 1
+          fi
+
+          if [ "${FINAL_STATUS}" != "Success" ]; then
+            echo "SSM command failed with status: ${FINAL_STATUS}"
+            exit 1
+          fi
 
       - name: Notify Discord (always)
         if: always()


### PR DESCRIPTION
## 📝 작업 내용
- `dev` 배포에서 SSM 명령 실행 상태를 polling 방식으로 확인하도록 수정했습니다.
- SSM 명령이 오래 걸리는 경우에도 일정 시간 동안 계속 대기할 수 있도록 개선했습니다.
- 배포 완료 후 `Stdout`/`Stderr`를 항상 출력하도록 변경해 원격 배포 실패 원인을 바로 확인할 수 있게 했습니다.
- `dev` 배포가 운영용 Parameter Store에 의존하지 않고 `ENV_DEV` 기반으로 동작하도록 정리했습니다.