### PR TITLE
[fix] 활성 배포 ID가 비어 있을 때 CodeDeploy 중지 호출 방지

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -262,8 +262,9 @@ jobs:
             --include-only-statuses Created Queued InProgress Ready \
             --query 'deployments[0]' \
             --output text)
+          ACTIVE_DEPLOYMENT_ID=$(printf '%s\n' "${ACTIVE_DEPLOYMENT_ID}" | tr -d '\r' | awk 'NF { print; exit }')
 
-          if [ "${ACTIVE_DEPLOYMENT_ID}" != "None" ]; then
+          if [ -n "${ACTIVE_DEPLOYMENT_ID}" ] && [ "${ACTIVE_DEPLOYMENT_ID}" != "None" ]; then
             echo "Active deployment found: ${ACTIVE_DEPLOYMENT_ID}"
             aws deploy stop-deployment \
               --deployment-id "${ACTIVE_DEPLOYMENT_ID}" \


### PR DESCRIPTION
## 📝 작업 내용
- `deploy_main` 단계에서 `aws deploy list-deployments` 결과를 한 번 정리하도록 수정했습니다.
- 활성 배포 ID가 비어 있거나 `None`인 경우 `stop-deployment`, `get-deployment`를 호출하지 않도록 수정했습니다.
- 실제 배포 ID가 있을 때만 기존 배포를 중지하고 새 배포를 진행하도록 분기 처리했습니다.

## 📢 참고 사항
- `.github/workflows/cd.yml`의 `deploy_main` 로직만 수정했습니다.