### PR TITLE
[refactor] sh 파일 수정 및 ocr precess/vlm 호출 타임아웃 연장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,11 @@ qdrant_storage/
 app/database/user_dataset/
 app/database/algo_concepts/
 
-
+### 테스트 파일 ###
+Dockerfile.ocr
+test_vlm.py
+test_ocr_publish.py
+workbook_router.py
 
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
     VLM_BASE_URL: str = "http://localhost:8001/v1"
     VLM_API_KEY: str = "EMPTY"
     VLM_MODEL: str = "Qwen/Qwen2.5-VL-7B-Instruct"
-    VLM_TIMEOUT_SEC: float = 60.0
+    VLM_TIMEOUT_SEC: float = 120.0
 
     # Gemini Flash (요약카드/퀴즈 생성)
     GEMINI_API_KEY: str = ""

--- a/app/workers/ocr_worker.py
+++ b/app/workers/ocr_worker.py
@@ -15,7 +15,7 @@ from app.domain.workbook.workbook_schemas import WorkbookQueueRequest, WorkbookR
 from app.queue.constants import OCR_REQUEST_QUEUE, OCR_EXCHANGE, OCR_RESPONSE_ROUTING_KEY
 from app.queue.rabbitmq import get_rabbitmq_channel, init_rabbitmq, close_rabbitmq
 
-OCR_PROCESS_TIMEOUT_SEC = 300
+OCR_PROCESS_TIMEOUT_SEC = 500
 
 
 def _utc_now_iso() -> str:

--- a/scripts/run_api_and_worker.sh
+++ b/scripts/run_api_and_worker.sh
@@ -4,29 +4,38 @@ set -eu
 APP_PORT="${APP_PORT:-8000}"
 
 python -m app.workers.ai_worker &
-WORKER_PID=$!
+AI_WORKER_PID=$!
+
+python -m app.workers.ocr_worker &
+OCR_WORKER_PID=$!
 
 uvicorn app.main:app --host 0.0.0.0 --port "${APP_PORT}" &
 API_PID=$!
 
 term() {
-  kill -TERM "$WORKER_PID" "$API_PID" 2>/dev/null || true
+  kill -TERM "$AI_WORKER_PID" "$OCR_WORKER_PID" "$API_PID" 2>/dev/null || true
 }
 
 trap term INT TERM
 
 while :; do
-  if ! kill -0 "$WORKER_PID" 2>/dev/null; then
-    wait "$WORKER_PID" || true
-    term
-    wait "$API_PID" 2>/dev/null || true
-    exit 1
+  if ! kill -0 "$AI_WORKER_PID" 2>/dev/null; then
+    echo "[ai_worker] died, restarting..."
+    python -m app.workers.ai_worker &
+    AI_WORKER_PID=$!
+  fi
+
+  if ! kill -0 "$OCR_WORKER_PID" 2>/dev/null; then
+    echo "[ocr_worker] died, restarting..."
+    python -m app.workers.ocr_worker &
+    OCR_WORKER_PID=$!
   fi
 
   if ! kill -0 "$API_PID" 2>/dev/null; then
     wait "$API_PID" || true
     term
-    wait "$WORKER_PID" 2>/dev/null || true
+    wait "$AI_WORKER_PID" 2>/dev/null || true
+    wait "$OCR_WORKER_PID" 2>/dev/null || true
     exit 1
   fi
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #81 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
1. 기존 sh 파일 문제점 : 워커가 죽으면 전체 컨테이너도 같이 종료. -> PID를 ai_worker용, ocr_worker용으로 분리 + 모니터링 루프 수정(조건문으로 워커가 죽으면 재시작, 컨테이너가 죽으면 전체종료)
2. ocr worker 와 vLM 인식 타임아웃 연장
- ocr worker : 300 -> 500
- vLM : 60 -> 120

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
