### PR TITLE
[fix] workflow 로그에서 env 값 마스킹

### DIFF
--- a/.github/workflows/cd-monitoring.yml
+++ b/.github/workflows/cd-monitoring.yml
@@ -47,6 +47,9 @@ jobs:
               exit 1
             fi
 
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
             echo "$key=$value" >> "$GITHUB_ENV"
           done <<< "$RAW_ENV_CONFIG"
 
@@ -124,8 +127,9 @@ jobs:
             --command-id "${COMMAND_ID}" \
             --instance-id "${MONITORING_INSTANCE_ID}"
 
-          aws ssm get-command-invocation \
+          FINAL_INVOCATION_STATUS=$(aws ssm get-command-invocation \
             --command-id "${COMMAND_ID}" \
             --instance-id "${MONITORING_INSTANCE_ID}" \
-            --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
-            --output json
+            --query "Status" \
+            --output text 2>/dev/null || echo "Unknown")
+          echo "Final SSM invocation status: ${FINAL_INVOCATION_STATUS}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,6 +56,9 @@ jobs:
               exit 1
             fi
 
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
             echo "$key=$value" >> "$GITHUB_ENV"
           done <<< "$RAW_ENV_CONFIG"
 
@@ -82,6 +85,7 @@ jobs:
           APP_ENV_CONTENT_BASE64=$(printf '%s\n' "$RAW_ENV_CONFIG" | \
             grep -Ev '^(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_REGION|ECR_REGISTRY|ECR_REPO|CODEDEPLOY_APP|CODEDEPLOY_GROUP|DEPLOY_BUCKET|DEPLOY_KEY|DISCORD_WEBHOOK|CONTAINER_NAME|HOST_PORT|APP_PORT|HEALTH_PATH|SSM_PARAM_NAME|APP_ENV_PATH|DEV_DEPLOY_SCRIPT_PATH)=' | \
             base64 -w0)
+          echo "::add-mask::$APP_ENV_CONTENT_BASE64"
 
           cat > /tmp/ssm-params.json <<EOF
           {"commands":["bash -lc \"set -euo pipefail; AWS_REGION='${AWS_REGION}' ECR_REGISTRY='${ECR_REGISTRY}' ECR_REPO='${ECR_REPO}' IMAGE_TAG='dev' CONTAINER_NAME='${CONTAINER_NAME}' HOST_PORT='${HOST_PORT}' APP_PORT='${APP_PORT}' HEALTH_PATH='${HEALTH_PATH}' APP_ENV_PATH='${APP_ENV_PATH}' APP_ENV_CONTENT_BASE64='${APP_ENV_CONTENT_BASE64}' '${DEV_DEPLOY_SCRIPT_PATH}'\""]}
@@ -127,11 +131,12 @@ jobs:
             esac
           done
 
-          aws ssm get-command-invocation \
+          FINAL_INVOCATION_STATUS=$(aws ssm get-command-invocation \
             --command-id "${COMMAND_ID}" \
             --instance-id "${INSTANCE_ID}" \
-            --query "{Status:Status,Stdout:StandardOutputContent,Stderr:StandardErrorContent}" \
-            --output json
+            --query "Status" \
+            --output text 2>/dev/null || echo "Unknown")
+          echo "Final SSM invocation status: ${FINAL_INVOCATION_STATUS}"
 
           if [ -z "${FINAL_STATUS}" ]; then
             echo "SSM command did not finish within the allotted time"
@@ -214,6 +219,9 @@ jobs:
               exit 1
             fi
 
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
             echo "$key=$value" >> "$GITHUB_ENV"
           done <<< "$RAW_ENV_CONFIG"
 
@@ -383,6 +391,9 @@ jobs:
               exit 1
             fi
 
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
             echo "$key=$value" >> "$GITHUB_ENV"
           done <<< "$RAW_ENV_CONFIG"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
             if ! [[ "$key" =~ ^[A-Z0-9_]+$ ]]; then
               continue
             fi
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
             echo "$key=$value" >> "$GITHUB_ENV"
           done <<< "$RAW_ENV_CONFIG"
 
@@ -150,6 +153,9 @@ jobs:
               exit 1
             fi
 
+            if [ -n "$value" ]; then
+              echo "::add-mask::$value"
+            fi
             echo "$key=$value" >> "$GITHUB_ENV"
           done <<< "$RAW_ENV_CONFIG"
 


### PR DESCRIPTION
## 📝 작업 내용
- workflow에서 `RAW_ENV_CONFIG`를 `$GITHUB_ENV`로 로드할 때 각 값을 `::add-mask::` 처리하도록 수정했습니다.
- dev/staging/prod 배포 워크플로우에서 민감한 env 값이 Actions 로그에 그대로 노출되지 않도록 변경했습니다.
- SSM 결과 출력 시 `Stdout/Stderr` 전체를 덤프하지 않고 최종 상태만 출력하도록 수정했습니다.
- 동일한 패턴이 있던 monitoring CD workflow도 같이 정리했습니다.

## 📢 참고 사항
- 포함 파일은 `.github/workflows/ci.yml`, `.github/workflows/cd.yml`, `.github/workflows/cd-monitoring.yml` 입니다.